### PR TITLE
Make configs reusable.

### DIFF
--- a/examples/complete-ecs/main.tf
+++ b/examples/complete-ecs/main.tf
@@ -32,12 +32,12 @@ module "vpc" {
 
 #----- ECS --------
 module "ecs" {
-  source = "../../"
+  source = "terraform-aws-modules/ecs/aws"
   name   = local.name
 }
 
 module "ec2-profile" {
-  source = "../../modules/ecs-instance-profile"
+  source  = "terraform-aws-modules/ecs/aws/modules/ecs-instance-profile"
   name   = local.name
 }
 

--- a/examples/complete-ecs/main.tf
+++ b/examples/complete-ecs/main.tf
@@ -37,7 +37,7 @@ module "ecs" {
 }
 
 module "ec2-profile" {
-  source  = "terraform-aws-modules/ecs/aws/modules/ecs-instance-profile"
+  source = "terraform-aws-modules/ecs/aws/modules/ecs-instance-profile"
   name   = local.name
 }
 


### PR DESCRIPTION
# Description

I was getting a lot of 'module not found' errors when testing this configs in my local, after a little digging I realized that couple of blocks are pointing to sources using relative paths.

To be clear, I'm not pulling all the the code under this repository, my testing directory/project only has the stuff listed under: https://github.com/terraform-aws-modules/terraform-aws-ecs/tree/master/examples/complete-ecs

Btw, I'm new w terraform so let me know in case i'm doing something wrong.

Thank you!

