### PR TITLE
Add tags to ECS instance profile role

### DIFF
--- a/modules/ecs-instance-profile/main.tf
+++ b/modules/ecs-instance-profile/main.tf
@@ -2,6 +2,8 @@ resource "aws_iam_role" "this" {
   name = "${var.name}_ecs_instance_role"
   path = "/ecs/"
 
+  tags = var.tags
+
   assume_role_policy = <<EOF
 {
   "Version": "2008-10-17",

--- a/modules/ecs-instance-profile/variables.tf
+++ b/modules/ecs-instance-profile/variables.tf
@@ -2,3 +2,9 @@ variable "name" {
   description = "Name to be used on all the resources as identifier"
   type        = string
 }
+
+variable "tags" {
+  description = "A map of tags to add to instance profile role"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Description

Allows adding custom tags to ECS instance profile role.

## Motivation and Context

We have a policy to tag all taggable AWS resources in the company. It would be great if we could tag this role as well.

## Breaking Changes

No breaking changes, as has an empty map default.

## How Has This Been Tested?

The change has been tested by referencing a fork repo with this change and applying.
