### PR TITLE
fix: Remove the dependency of hard coded region and availability zones

### DIFF
--- a/examples/complete-ecs/main.tf
+++ b/examples/complete-ecs/main.tf
@@ -1,13 +1,13 @@
-provider "aws" {
-  region = "eu-west-1"
-}
-
 locals {
   name        = "complete-ecs"
   environment = "dev"
 
   # This is the convention we use to know what belongs to each other
   ec2_resources_name = "${local.name}-${local.environment}"
+}
+
+data "aws_availability_zones" "available" {
+  state = "available"
 }
 
 module "vpc" {
@@ -18,7 +18,7 @@ module "vpc" {
 
   cidr = "10.1.0.0/16"
 
-  azs             = ["eu-west-1a", "eu-west-1b"]
+  azs             = data.aws_availability_zones.available.names
   private_subnets = ["10.1.1.0/24", "10.1.2.0/24"]
   public_subnets  = ["10.1.11.0/24", "10.1.12.0/24"]
 


### PR DESCRIPTION
## Description
remove the dependency of hard coded region and available zones in examples.

## Motivation and Context

Normally we set `AWS_REGION` or `AWS_DEFAULT_REGION` environment variable, or set `region` in aws credentials file already. 

this PR removes the dependency of hard coded region and available zones, so end users can directly run the example without any codes to be updated in examples.

## Breaking Changes
No, just a change in example

but if the region has three or four available zone, it would create more resources than before. 

If you do want to limit the number of AZs to 2 only, I can adjust the code to:

```
 azs             = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1]]
```
## How Has This Been Tested?
```
terraform init
terraform plan
terraform apply
```
