### PR TITLE
fix: make the example workable

### DIFF
--- a/examples/complete-ecs/main.tf
+++ b/examples/complete-ecs/main.tf
@@ -1,13 +1,13 @@
-provider "aws" {
-  region = "eu-west-1"
-}
-
 locals {
   name        = "complete-ecs"
   environment = "dev"
 
   # This is the convention we use to know what belongs to each other
   ec2_resources_name = "${local.name}-${local.environment}"
+}
+
+data "aws_availability_zones" "available" {
+  state = "available"
 }
 
 module "vpc" {
@@ -18,7 +18,7 @@ module "vpc" {
 
   cidr = "10.1.0.0/16"
 
-  azs             = ["eu-west-1a", "eu-west-1b"]
+  azs             = data.aws_availability_zones.available.names
   private_subnets = ["10.1.1.0/24", "10.1.2.0/24"]
   public_subnets  = ["10.1.11.0/24", "10.1.12.0/24"]
 

--- a/examples/complete-ecs/main.tf
+++ b/examples/complete-ecs/main.tf
@@ -18,11 +18,11 @@ module "vpc" {
 
   cidr = "10.1.0.0/16"
 
-  azs             = data.aws_availability_zones.available.names
+  azs             = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1]]
   private_subnets = ["10.1.1.0/24", "10.1.2.0/24"]
   public_subnets  = ["10.1.11.0/24", "10.1.12.0/24"]
 
-  enable_nat_gateway = false # this is faster, but should be "true" for real
+  enable_nat_gateway = true
 
   tags = {
     Environment = local.environment
@@ -86,9 +86,9 @@ module "this" {
   asg_name                  = local.ec2_resources_name
   vpc_zone_identifier       = module.vpc.private_subnets
   health_check_type         = "EC2"
-  min_size                  = 0
-  max_size                  = 1
-  desired_capacity          = 0
+  min_size                  = 1
+  max_size                  = 2
+  desired_capacity          = 1
   wait_for_capacity_timeout = 0
 
   tags = [


### PR DESCRIPTION
## Description
with original setting, nat gateway is disable, we have no chance to know why the ec2 instance can't be added to ECS cluster automatically, because when the ec2 instance started, it has a yum update job failed (no internet access, blocked and failed)

second, the default autoscaling group is set to 0 for desired size, it makes me crazy why I can't see it in ECS directly. 

This PR fixed both problems 

## Motivation and Context
This PR fixed both problems described above.

## Breaking Changes
No, it is example change.

## How Has This Been Tested?

```
terraform init
terraform plan
terraform apply
```