### PR TITLE
fix: Converting type of `default_capacity_provider_strategy` from map to list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 terraform.tfstate
 *.tfstate*
 terraform.tfvars
+.terraform.lock.hcl

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ module "ecs" {
 | capacity\_providers | List of short names of one or more capacity providers to associate with the cluster. Valid values also include FARGATE and FARGATE\_SPOT. | `list(string)` | `[]` | no |
 | container\_insights | Controls if ECS Cluster has container insights enabled | `bool` | `false` | no |
 | create\_ecs | Controls if ECS should be created | `bool` | `true` | no |
-| default\_capacity\_provider\_strategy | The capacity provider strategy to use by default for the cluster. Can be one or more. | `map(any)` | `{}` | no |
+| default\_capacity\_provider\_strategy | The capacity provider strategy to use by default for the cluster. Can be one or more. | `list(map(any))` | `[]` | no |
 | name | Name to be used on all the resources as identifier, also the name of the ECS cluster | `string` | `null` | no |
 | tags | A map of tags to add to ECS Cluster | `map(string)` | `{}` | no |
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,11 @@ module "ecs" {
 
   capacity_providers = ["FARGATE", "FARGATE_SPOT"]
 
-  default_capacity_provider_strategy = {
-    capacity_provider = "FARGATE_SPOT"
-  }
+  default_capacity_provider_strategy = [
+    {
+      capacity_provider = "FARGATE_SPOT"
+    }
+  ]
 
   tags = {
     Environment = "Development"

--- a/examples/complete-ecs/main.tf
+++ b/examples/complete-ecs/main.tf
@@ -39,9 +39,9 @@ module "ecs" {
 
   capacity_providers = ["FARGATE", "FARGATE_SPOT", aws_ecs_capacity_provider.prov1.name]
 
-  default_capacity_provider_strategy = {
+  default_capacity_provider_strategy = [{
     capacity_provider = aws_ecs_capacity_provider.prov1.name # "FARGATE_SPOT"
-  }
+  }]
 
   tags = {
     Environment = local.environment

--- a/examples/complete-ecs/service-hello-world/versions.tf
+++ b/examples/complete-ecs/service-hello-world/versions.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_version = ">= 0.12.6, < 0.14"
+  required_version = ">= 0.12.6"
 
   required_providers {
-    aws = ">= 2.0, < 4.0"
+    aws = ">= 2.0"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ resource "aws_ecs_cluster" "this" {
   capacity_providers = var.capacity_providers
 
   dynamic "default_capacity_provider_strategy" {
-    for_each = length(keys(var.default_capacity_provider_strategy)) == 0 ? [] : [var.default_capacity_provider_strategy]
+    for_each = var.default_capacity_provider_strategy
     iterator = strategy
 
     content {

--- a/variables.tf
+++ b/variables.tf
@@ -18,8 +18,8 @@ variable "capacity_providers" {
 
 variable "default_capacity_provider_strategy" {
   description = "The capacity provider strategy to use by default for the cluster. Can be one or more."
-  type        = map(any)
-  default     = {}
+  type        = list(map(any))
+  default     = []
 }
 
 variable "container_insights" {


### PR DESCRIPTION
## Description
As the description of the variable says the default can be one or more. Also, the ECS supports multiple defaults, the changes have been made.

## Motivation and Context
It allows to add multiple default capacity provider strategy for the ECS services.
<img width="787" alt="Screenshot 2021-01-26 at 10 34 25" src="https://user-images.githubusercontent.com/4235912/105801836-1e34c100-5fc2-11eb-890b-257417f8715b.png">

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
I made the changes on my local module and applied `terraform plan`.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->