### PR TITLE
Fix weight example

### DIFF
--- a/examples/complete-ecs/main.tf
+++ b/examples/complete-ecs/main.tf
@@ -41,6 +41,7 @@ module "ecs" {
 
   default_capacity_provider_strategy = [{
     capacity_provider = aws_ecs_capacity_provider.prov1.name # "FARGATE_SPOT"
+    weight            = "1"
   }]
 
   tags = {

--- a/examples/complete-ecs/main.tf
+++ b/examples/complete-ecs/main.tf
@@ -41,7 +41,6 @@ module "ecs" {
 
   default_capacity_provider_strategy = [{
     capacity_provider = aws_ecs_capacity_provider.prov1.name # "FARGATE_SPOT"
-    weight            = "1"
   }]
 
   tags = {


### PR DESCRIPTION
## Description
Added `weight = "1"` under default strategy provider in full-ecs-example. Also there's an issue there #27 

## Motivation and Context
The example wasn't working fully.

## Breaking Changes
No

## How Has This Been Tested?
Tested in my own account with directly `terraform apply`

