### PR TITLE
fixed no capacity providers with a weight value greater than 0 error …

### DIFF
--- a/examples/complete-ecs/main.tf
+++ b/examples/complete-ecs/main.tf
@@ -41,6 +41,7 @@ module "ecs" {
 
   default_capacity_provider_strategy = [{
     capacity_provider = aws_ecs_capacity_provider.prov1.name # "FARGATE_SPOT"
+    weight            = "1"
   }]
 
   tags = {


### PR DESCRIPTION
## Description
added `weight = "1"` under full example 

## Motivation and Context
fixing the error in example, issue: #27 


## How Has This Been Tested?
tested in aws environment
