### PR TITLE
chore: update documentation based on latest `terraform-docs` which includes module and resource sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,29 @@
-.terraform
-terraform.tfstate
-*.tfstate*
-terraform.tfvars
+# Local .terraform directories
+**/.terraform/*
+
+# Terraform lockfile
 .terraform.lock.hcl
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Exclude all .tfvars files, which are likely to contain sentitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.45.0
+    rev: v1.46.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.44.0
+    rev: v1.45.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -21,6 +21,6 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v3.4.0
     hooks:
       - id: check-merge-conflict

--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ module "ecs" {
 |------|---------|
 | aws | >= 2.48 |
 
+## Modules
+
+No Modules.
+
+## Resources
+
+| Name |
+|------|
+| [aws_ecs_cluster](https://registry.terraform.io/providers/hashicorp/aws/2.48/docs/resources/ecs_cluster) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -90,7 +100,6 @@ module "ecs" {
 | this\_ecs\_cluster\_arn | ARN of the ECS Cluster |
 | this\_ecs\_cluster\_id | ID of the ECS Cluster |
 | this\_ecs\_cluster\_name | The name of the ECS cluster |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/examples/complete-ecs/README.md
+++ b/examples/complete-ecs/README.md
@@ -54,6 +54,26 @@ Current version creates an high-available VPC with instances that are attached t
 | aws | >= 2.48 |
 | template | >= 2.0 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| asg | terraform-aws-modules/autoscaling/aws | ~> 3.0 |
+| disabled_ecs | ../../ |  |
+| ec2_profile | ../../modules/ecs-instance-profile |  |
+| ecs | ../../ |  |
+| hello_world | ./service-hello-world |  |
+| vpc | terraform-aws-modules/vpc/aws | ~> 2.0 |
+
+## Resources
+
+| Name |
+|------|
+| [aws_ami](https://registry.terraform.io/providers/hashicorp/aws/2.48/docs/data-sources/ami) |
+| [aws_availability_zones](https://registry.terraform.io/providers/hashicorp/aws/2.48/docs/data-sources/availability_zones) |
+| [aws_ecs_capacity_provider](https://registry.terraform.io/providers/hashicorp/aws/2.48/docs/resources/ecs_capacity_provider) |
+| [template_file](https://registry.terraform.io/providers/hashicorp/template/2.0/docs/data-sources/file) |
+
 ## Inputs
 
 No input.
@@ -61,5 +81,4 @@ No input.
 ## Outputs
 
 No output.
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->


### PR DESCRIPTION
## Description
- update documentation based on latest `terraform-docs` which includes module and resource sections
- `.gitignore` updated using GitHub provided default standard + 0.14 lockfile ignore

## Motivation and Context
- these are two new sections provided by [`terraform-docs` now](https://github.com/terraform-docs/terraform-docs/releases/tag/v0.11.0)

## Breaking Changes
No

## How Has This Been Tested?
N/A
