### PR TITLE
fix: 'One of launch_configuration, launch_template, or mixed_instance must be set for an Auto Scaling Group'

### DIFF
--- a/examples/complete-ecs/main.tf
+++ b/examples/complete-ecs/main.tf
@@ -101,7 +101,9 @@ module "asg" {
   name = local.ec2_resources_name
 
   # Launch configuration
-  lc_name = local.ec2_resources_name
+  lc_name   = local.ec2_resources_name
+  use_lc    = true
+  create_lc = true
 
   image_id                 = data.aws_ami.amazon_linux_ecs.id
   instance_type            = "t2.micro"


### PR DESCRIPTION
## Description
Executing `terraform apply` in the example-complete folder you will receive a message error likes

```
╷
│ Error: One of `launch_configuration`, `launch_template`, or `mixed_instances_policy` must be set for an Auto Scaling Group
│
│   with module.asg.aws_autoscaling_group.this[0],
│   on .terraform/modules/asg/main.tf line 309, in resource "aws_autoscaling_group" "this":
│  309: resource "aws_autoscaling_group" "this" {
│
╵
```

## Motivation and Context
This commit will solve the message error. 

Consulting [Auto Scaling Module Reference](https://github.com/terraform-aws-modules/terraform-aws-autoscaling#conditional-creation) I have used conditional creation for autoscaling group and launch configuration

## Breaking Changes
There aren't breaking changes

## How Has This Been Tested?
 I have tested and validated these changes using executing `terraform apply` in complete-ecs examples folder.

Tested with Terraform v0.15.3
