### PR TITLE
fix: Complete ECS example (IAM role not configured in ASG)

### DIFF
--- a/examples/complete-ecs/main.tf
+++ b/examples/complete-ecs/main.tf
@@ -105,11 +105,11 @@ module "asg" {
   use_lc    = true
   create_lc = true
 
-  image_id                 = data.aws_ami.amazon_linux_ecs.id
-  instance_type            = "t2.micro"
-  security_groups          = [module.vpc.default_security_group_id]
-  iam_instance_profile_arn = module.ec2_profile.iam_instance_profile_arn
-  user_data                = data.template_file.user_data.rendered
+  image_id                  = data.aws_ami.amazon_linux_ecs.id
+  instance_type             = "t2.micro"
+  security_groups           = [module.vpc.default_security_group_id]
+  iam_instance_profile_name = module.ec2_profile.iam_instance_profile_id
+  user_data                 = data.template_file.user_data.rendered
 
   # Auto scaling group
   vpc_zone_identifier       = module.vpc.private_subnets


### PR DESCRIPTION
## Description

The Complete ECS Example don't work. Don't configure the IAM Role in ASG.

## Motivation and Context
This is because the example uses launch configuration and the variable iam_instance_profile_arn.
The variable iam_instance_profile_arn should be use with launch template.
With launch configurations should use the variable iam_instance_profile_name.

fixes #42

## Breaking Changes
none
## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects in own aws infrastructure.