### PR TITLE
feat: Propagate tags to aws_iam_instance_profile

### DIFF
--- a/modules/ecs-instance-profile/main.tf
+++ b/modules/ecs-instance-profile/main.tf
@@ -25,6 +25,8 @@ EOF
 resource "aws_iam_instance_profile" "this" {
   name = "${var.name}_ecs_instance_profile"
   role = aws_iam_role.this.name
+  
+  tags = var.tags
 }
 
 resource "aws_iam_role_policy_attachment" "ecs_ec2_role" {


### PR DESCRIPTION
## Description
Propagate tags to aws_iam_instance_profile

## Motivation and Context
It allows to have proper tagging for all the resources. Useful for FinOps.

## Breaking Changes
No breaking changes.

## How Has This Been Tested?
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
