### PR TITLE
feat: Add aws_ecs_cluster_capacity_providers resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_ecs_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster) | resource |
+| [aws_ecs_cluster_capacity_providers.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster_capacity_providers) | resource |
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -58,13 +58,13 @@ module "ecs" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.48 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.74 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.48 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.74 |
 
 ## Modules
 

--- a/examples/complete-ecs/README.md
+++ b/examples/complete-ecs/README.md
@@ -44,13 +44,13 @@ Current version creates an high-available VPC with instances that are attached t
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.48 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.74 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.48 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.74 |
 
 ## Modules
 

--- a/examples/complete-ecs/versions.tf
+++ b/examples/complete-ecs/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.48"
+      version = ">= 3.74"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -3,6 +3,19 @@ resource "aws_ecs_cluster" "this" {
 
   name = var.name
 
+  setting {
+    name  = "containerInsights"
+    value = var.container_insights ? "enabled" : "disabled"
+  }
+
+  tags = var.tags
+}
+
+resource "aws_ecs_cluster_capacity_providers" "this" {
+  count = var.create_ecs ? 1 : 0
+
+  cluster_name = aws_ecs_cluster.this[0].name
+
   capacity_providers = var.capacity_providers
 
   dynamic "default_capacity_provider_strategy" {
@@ -15,11 +28,4 @@ resource "aws_ecs_cluster" "this" {
       base              = lookup(strategy.value, "base", null)
     }
   }
-
-  setting {
-    name  = "containerInsights"
-    value = var.container_insights ? "enabled" : "disabled"
-  }
-
-  tags = var.tags
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.48"
+      version = ">= 3.74"
     }
   }
 }


### PR DESCRIPTION
## Description
Add an [aws_ecs_cluster_capacity_providers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster_capacity_providers) resource.

## Motivation and Context
AWS provider v4 has deprecated declaring the capacity provider in the `aws_ecs_cluster` resource.
Fixes https://github.com/terraform-aws-modules/terraform-aws-ecs/issues/54.

## Breaking Changes
This resource was introduced in v3.74.0 so will break anything using an earlier version.
See https://github.com/hashicorp/terraform-provider-aws/pull/22672.

## How Has This Been Tested?
Tested using an existing deployment.
