### PR TITLE
fix: Issue 56

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ No modules.
 | <a name="input_default_capacity_provider_strategy"></a> [default\_capacity\_provider\_strategy](#input\_default\_capacity\_provider\_strategy) | The capacity provider strategy to use by default for the cluster. Can be one or more. | `list(map(any))` | `[]` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name to be used on all the resources as identifier, also the name of the ECS cluster | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to ECS Cluster | `map(string)` | `{}` | no |
+| <a name="input_configuration"></a> [configuration](#input\_configuration)                                                                      | A dynamic configuration block for the execute-command functionality at cluster level                                                      | <code> object({<br>  kms_key_id                     = string <br> logging                        = string <br> cloud_watch_encryption_enabled=bool <br> cloud_watch_log_group_name=string <br> s3_bucket_name                 = string <br> s3_bucket_encryption_enabled   = bool <br> s3_key_prefix                  = string <br> }) </code> | <code> {<br>  kms_key_id                     = null <br> logging                        = "NONE" <br> cloud_watch_encryption_enabled=null <br> cloud_watch_log_group_name=null <br> s3_bucket_name                 = null <br> s3_bucket_encryption_enabled   = null <br> s3_key_prefix                  = null <br> } </code> |    no    |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,25 @@ resource "aws_ecs_cluster" "this" {
     value = var.container_insights ? "enabled" : "disabled"
   }
 
+  configuration {
+    execute_command_configuration {
+      kms_key_id = var.configuration.kms_key_id
+      logging    = var.configuration.logging
+
+      dynamic "log_configuration" {
+        for_each = var.configuration.logging == "OVERRIDE" ? [var.configuration] : []
+        content {
+          cloud_watch_encryption_enabled = log_configuration.value.cloud_watch_encryption_enabled
+          cloud_watch_log_group_name     = log_configuration.value.cloud_watch_log_group_name
+          s3_bucket_name                 = log_configuration.value.s3_bucket_name
+          s3_bucket_encryption_enabled   = log_configuration.value.s3_bucket_encryption_enabled
+          s3_key_prefix                  = log_configuration.value.s3_key_prefix
+        }
+      }
+    }
+
+  }
+
   tags = var.tags
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -33,3 +33,26 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "configuration" {
+  description = "Define a dynamic configuration block for the execute-command functionality at cluster level. Valid values for logging (if specified) are: NONE, DEFAULT, OVERRIDE. If OVERRIDE is specified then the cloudwatch group name or the S3 bucket name is mandatory"
+  type = object({
+    kms_key_id                     = string
+    logging                        = string
+    cloud_watch_encryption_enabled = bool
+    cloud_watch_log_group_name     = string
+    s3_bucket_name                 = string
+    s3_bucket_encryption_enabled   = bool
+    s3_key_prefix                  = string
+
+  })
+  default = {
+    logging                        = "NONE"
+    kms_key_id                     = null
+    cloud_watch_encryption_enabled = null
+    cloud_watch_log_group_name     = null
+    s3_bucket_name                 = null
+    s3_bucket_encryption_enabled   = null
+    s3_key_prefix                  = null
+  }
+}


### PR DESCRIPTION
## Description
Add support for logging capabilities when using [execution-command](https://aws.amazon.com/blogs/containers/new-using-amazon-ecs-exec-access-your-containers-fargate-ec2/) functionality provided by AWS.

## Motivation and Context
It is required in order to log information while using the [execution-command](https://aws.amazon.com/blogs/containers/new-using-amazon-ecs-exec-access-your-containers-fargate-ec2/) functionality provided by AWS.
Fix: #56 

## Breaking Changes
No breaking changes, it shouldn't affect any functionality of the module.

## How Has This Been Tested?
Tested using an existing deployment.
