### PR TITLE
ECS Cluster settings are dynamic (tests pending)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,11 +3,14 @@ resource "aws_ecs_cluster" "this" {
 
   name = var.name
 
-  setting {
-    name  = "containerInsights"
-    value = var.container_insights ? "enabled" : "disabled"
+  dynamic "setting" {
+    for_each = var.container_insights ? [1] : []
+    content {
+      name  = "containerInsights"
+      value = var.container_insights ? "enabled" : "disabled"
+    }
   }
-
+  
   tags = var.tags
 }
 


### PR DESCRIPTION
## Description
This PR converts settings section to be dynamic and removes the whole section if the container insights are disabled.

## Motivation and Context
Fixes https://github.com/terraform-aws-modules/terraform-aws-ecs/issues/58

## Breaking Changes
No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have tested and validated these changes using internal project which is a simple module call.
- [ ] I have executed `pre-commit run -a` on my pull request
