### PR TITLE
fix: Add empty map to `execute_command_configuration` to avoid plugin crash from interface conversion

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.3.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer

--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ resource "aws_ecs_cluster" "this" {
 
     content {
       dynamic "execute_command_configuration" {
-        for_each = try([configuration.value.execute_command_configuration], [])
+        for_each = try([configuration.value.execute_command_configuration], [{}])
 
         content {
           kms_key_id = try(execute_command_configuration.value.kms_key_id, null)


### PR DESCRIPTION
## Description
- Add empty map to `execute_command_configuration` to avoid plugin crash from interface conversion

## Motivation and Context
- Closes #61

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
