### PR TITLE
fix: Complete example EC2 instance cluster joining issue

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -175,7 +175,7 @@ module "vpc" {
   public_subnets  = ["10.99.0.0/24", "10.99.1.0/24", "10.99.2.0/24"]
   private_subnets = ["10.99.3.0/24", "10.99.4.0/24", "10.99.5.0/24"]
 
-  enable_nat_gateway      = false
+  enable_nat_gateway      = true
   single_nat_gateway      = true
   enable_dns_hostnames    = true
   map_public_ip_on_launch = false


### PR DESCRIPTION
## Description

The goal of this PR is to resolve EC2 instances not being able to successfully join the ECS cluster produced by `examples/complete/` by switching `enable_nat_gateway` from `false` to `true`.

## Motivation and Context

This PR resolves #63
The motivation is to ensure the examples can successfully bootstrap an ECS cluster and place tasks on the newly provisioned EC2 instances.

## Breaking Changes

None.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
