### PR TITLE
docs: Correct examples in README to correct `name` -> `cluster_name`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.72.1
+    rev: v1.73.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Terraform module which creates ECS (Elastic Container Service) resources on AWS.
 module "ecs" {
   source = "terraform-aws-modules/ecs/aws"
 
-  name = "ecs-fargate"
+  cluster_name = "ecs-fargate"
 
   cluster_configuration = {
     execute_command_configuration = {
@@ -53,7 +53,7 @@ module "ecs" {
 module "ecs" {
   source = "terraform-aws-modules/ecs/aws"
 
-  name = "ecs-ec2"
+  cluster_name = "ecs-ec2"
 
   cluster_configuration = {
     execute_command_configuration = {
@@ -111,7 +111,7 @@ module "ecs" {
 module "ecs" {
   source = "terraform-aws-modules/ecs/aws"
 
-  name = "ecs-mixed"
+  cluster_name = "ecs-mixed"
 
   cluster_configuration = {
     execute_command_configuration = {


### PR DESCRIPTION
## Description
- Correct examples in README to correct `name` -> `cluster_name`

## Motivation and Context
- Docs currently reference `name` but it should be `cluster_name`

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
