### PR TITLE
feat: Export cluster name since cluster ID is exporting the ARN

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ No modules.
 | <a name="output_cluster_arn"></a> [cluster\_arn](#output\_cluster\_arn) | ARN that identifies the cluster |
 | <a name="output_cluster_capacity_providers"></a> [cluster\_capacity\_providers](#output\_cluster\_capacity\_providers) | Map of cluster capacity providers attributes |
 | <a name="output_cluster_id"></a> [cluster\_id](#output\_cluster\_id) | ID that identifies the cluster |
+| <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | Name that identifies the cluster |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -62,4 +62,5 @@ No inputs.
 | <a name="output_cluster_arn"></a> [cluster\_arn](#output\_cluster\_arn) | ARN that identifies the cluster |
 | <a name="output_cluster_capacity_providers"></a> [cluster\_capacity\_providers](#output\_cluster\_capacity\_providers) | Map of cluster capacity providers attributes |
 | <a name="output_cluster_id"></a> [cluster\_id](#output\_cluster\_id) | ID that identifies the cluster |
+| <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | Name that identifies the cluster |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -12,6 +12,11 @@ output "cluster_id" {
   value       = module.ecs.cluster_id
 }
 
+output "cluster_name" {
+  description = "Name that identifies the cluster"
+  value       = module.ecs.cluster_name
+}
+
 ################################################################################
 # Cluster Capacity Providers
 ################################################################################

--- a/examples/fargate/README.md
+++ b/examples/fargate/README.md
@@ -55,4 +55,5 @@ No inputs.
 | <a name="output_cluster_arn"></a> [cluster\_arn](#output\_cluster\_arn) | ARN that identifies the cluster |
 | <a name="output_cluster_capacity_providers"></a> [cluster\_capacity\_providers](#output\_cluster\_capacity\_providers) | Map of cluster capacity providers attributes |
 | <a name="output_cluster_id"></a> [cluster\_id](#output\_cluster\_id) | ID that identifies the cluster |
+| <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | Name that identifies the cluster |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/fargate/outputs.tf
+++ b/examples/fargate/outputs.tf
@@ -12,6 +12,11 @@ output "cluster_id" {
   value       = module.ecs.cluster_id
 }
 
+output "cluster_name" {
+  description = "Name that identifies the cluster"
+  value       = module.ecs.cluster_name
+}
+
 ################################################################################
 # Cluster Capacity Providers
 ################################################################################

--- a/outputs.tf
+++ b/outputs.tf
@@ -12,6 +12,11 @@ output "cluster_id" {
   value       = try(aws_ecs_cluster.this[0].id, null)
 }
 
+output "cluster_name" {
+  description = "Name that identifies the cluster"
+  value       = try(aws_ecs_cluster.this[0].name, null)
+}
+
 ################################################################################
 # Cluster Capacity Providers
 ################################################################################


### PR DESCRIPTION
## Description
- Export cluster name since cluster ID is exporting the ARN

## Motivation and Context
- When integrating with other services, the cluster name is required for some inputs. However, the cluster ID is currently the cluster ARN as opposed to other places where IDs are typically a unique ID or the resource name. The name output is necessary to map dependencies correctly

## Breaking Changes
- No

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
