### PR TITLE
fix: Allow for both Fargate and EC2/Autoscaling capacity providers in same cluster

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.73.0
+    rev: v1.74.1
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ No modules.
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the cluster (up to 255 letters, numbers, hyphens, and underscores) | `string` | `""` | no |
 | <a name="input_cluster_settings"></a> [cluster\_settings](#input\_cluster\_settings) | Configuration block(s) with cluster settings. For example, this can be used to enable CloudWatch Container Insights for a cluster | `map(string)` | <pre>{<br>  "name": "containerInsights",<br>  "value": "enabled"<br>}</pre> | no |
 | <a name="input_create"></a> [create](#input\_create) | Determines whether resources will be created (affects all resources) | `bool` | `true` | no |
+| <a name="input_default_capacity_provider_use_fargate"></a> [default\_capacity\_provider\_use\_fargate](#input\_default\_capacity\_provider\_use\_fargate) | Determines whether to use Fargate or autoscaling for default capacity provider strategy | `bool` | `true` | no |
 | <a name="input_fargate_capacity_providers"></a> [fargate\_capacity\_providers](#input\_fargate\_capacity\_providers) | Map of Fargate capacity provider definitions to use for the cluster | `any` | `{}` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -42,6 +42,14 @@ module "ecs" {
     }
   }
 
+  default_capacity_provider_use_fargate = false
+
+  # Capacity provider - Fargate
+  fargate_capacity_providers = {
+    FARGATE      = {}
+    FARGATE_SPOT = {}
+  }
+
   # Capacity provider - autoscaling groups
   autoscaling_capacity_providers = {
     one = {

--- a/variables.tf
+++ b/variables.tf
@@ -39,6 +39,12 @@ variable "cluster_settings" {
 # Capacity Providers
 ################################################################################
 
+variable "default_capacity_provider_use_fargate" {
+  description = "Determines whether to use Fargate or autoscaling for default capacity provider strategy"
+  type        = bool
+  default     = true
+}
+
 variable "fargate_capacity_providers" {
   description = "Map of Fargate capacity provider definitions to use for the cluster"
   type        = any


### PR DESCRIPTION
## Description
- Allow for both Fargate and EC2/Autoscaling capacity providers in same cluster

## Motivation and Context
- Closes #68
- Allows users to use both Fargate and EC2/Autoscaling capacity providers within the same cluster

## Breaking Changes
- No; if users are currently using EC2/Autoscaling as their default capacity provider strategy, they will want to set `default_capacity_provider_use_fargate = false`

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
