### PR TITLE
docs: Add example showing `nonsensitive()` for pulling images from SSM parameter, add spot instance usage to examples

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.77.2
+    rev: v1.77.3
     hooks:
       - id: terraform_fmt
       - id: terraform_wrapper_module_for_each

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -53,6 +53,7 @@ Note that this example may create resources which will incur monetary charges on
 |------|------|
 | [aws_service_discovery_http_namespace.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/service_discovery_http_namespace) | resource |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
+| [aws_ssm_parameter.fluentbit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 
 ## Inputs
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -57,7 +57,7 @@ module "ecs" {
           cpu       = 512
           memory    = 1024
           essential = true
-          image     = "public.ecr.aws/aws-observability/aws-for-fluent-bit:2.31.9"
+          image     = nonsensitive(data.aws_ssm_parameter.fluentbit.value)
           firelens_configuration = {
             type = "fluentbit"
           }
@@ -165,6 +165,10 @@ module "service_disabled" {
 ################################################################################
 # Supporting Resources
 ################################################################################
+
+data "aws_ssm_parameter" "fluentbit" {
+  name = "/aws/service/aws-for-fluent-bit/stable"
+}
 
 resource "aws_service_discovery_http_namespace" "this" {
   name        = local.name

--- a/examples/fargate/README.md
+++ b/examples/fargate/README.md
@@ -51,6 +51,7 @@ Note that this example may create resources which will incur monetary charges on
 |------|------|
 | [aws_service_discovery_http_namespace.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/service_discovery_http_namespace) | resource |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
+| [aws_ssm_parameter.fluentbit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 
 ## Inputs
 

--- a/examples/fargate/main.tf
+++ b/examples/fargate/main.tf
@@ -68,11 +68,12 @@ module "ecs_service" {
       cpu       = 512
       memory    = 1024
       essential = true
-      image     = "public.ecr.aws/aws-observability/aws-for-fluent-bit:2.31.9"
+      image     = nonsensitive(data.aws_ssm_parameter.fluentbit.value)
       firelens_configuration = {
         type = "fluentbit"
       }
       memory_reservation = 50
+      user               = "0"
     }
 
     (local.container_name) = {
@@ -156,6 +157,10 @@ module "ecs_service" {
 ################################################################################
 # Supporting Resources
 ################################################################################
+
+data "aws_ssm_parameter" "fluentbit" {
+  name = "/aws/service/aws-for-fluent-bit/stable"
+}
 
 resource "aws_service_discovery_http_namespace" "this" {
   name        = local.name


### PR DESCRIPTION
## Description
- Add example showing `nonsensitive()` for pulling images from SSM parameter
- Add spot instance usage to examples

## Motivation and Context
- Demonstrates how to use SSM parameter data source in container definition without making the entire object + task definition outputs sensitive 
- Resolves #77 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
