### PR TITLE
fix: Ensure that launch type is not specified when a capacity provider strategy is set on a service

### DIFF
--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -78,7 +78,7 @@ resource "aws_ecs_service" "this" {
   force_new_deployment               = local.is_external_deployment ? null : var.force_new_deployment
   health_check_grace_period_seconds  = var.health_check_grace_period_seconds
   iam_role                           = local.iam_role_arn
-  launch_type                        = local.is_external_deployment ? null : var.launch_type
+  launch_type                        = local.is_external_deployment || length(var.capacity_provider_strategy) > 0 ? null : var.launch_type
 
   dynamic "load_balancer" {
     # Set by task set if deployment controller is external
@@ -264,7 +264,7 @@ resource "aws_ecs_service" "ignore_task_definition" {
   force_new_deployment               = local.is_external_deployment ? null : var.force_new_deployment
   health_check_grace_period_seconds  = var.health_check_grace_period_seconds
   iam_role                           = local.iam_role_arn
-  launch_type                        = local.is_external_deployment ? null : var.launch_type
+  launch_type                        = local.is_external_deployment || length(var.capacity_provider_strategy) > 0 ? null : var.launch_type
 
   dynamic "load_balancer" {
     # Set by task set if deployment controller is external
@@ -1047,7 +1047,7 @@ resource "aws_ecs_task_set" "this" {
     }
   }
 
-  launch_type = var.launch_type
+  launch_type = length(var.capacity_provider_strategy) > 0 ? null : var.launch_type
 
   dynamic "capacity_provider_strategy" {
     for_each = var.capacity_provider_strategy
@@ -1128,7 +1128,7 @@ resource "aws_ecs_task_set" "ignore_task_definition" {
     }
   }
 
-  launch_type = var.launch_type
+  launch_type = length(var.capacity_provider_strategy) > 0 ? null : var.launch_type
 
   dynamic "capacity_provider_strategy" {
     for_each = var.capacity_provider_strategy


### PR DESCRIPTION
## Description
- Ensure that launch type is not specified when a capacity provider strategy is set on a service
- Update EC2 autoscaling example to show use of capacity providers created

## Motivation and Context
- You cannot set both a launch type and capacity provider strategy on a service; its one or the other. By default the module is designed around Fargate so this is the default launch type. However, the launch type should be `null` when a capacity provider strategy is provided
- Currently the EC2 example incorrectly shows capacity provider strategy usage. This PR corrects that

## Breaking Changes
- No

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
