### PR TITLE
fix: Missing field LogConfiguration.LogDriver error when enable_cloudwatch_logging is false

### DIFF
--- a/modules/container-definition/main.tf
+++ b/modules/container-definition/main.tf
@@ -36,7 +36,7 @@ locals {
     interactive            = var.interactive
     links                  = local.is_not_windows && length(var.links) > 0 ? var.links : null
     linuxParameters        = local.is_not_windows && length(var.linux_parameters) > 0 ? var.linux_parameters : null
-    logConfiguration       = local.log_configuration
+    logConfiguration       = length(local.log_configuration) > 0 ? local.log_configuration : null
     memory                 = var.memory
     memoryReservation      = var.memory_reservation
     mountPoints            = length(var.mount_points) > 0 ? var.mount_points : null


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
If we pass `enable_cloudwatch_logging = false` on a service `container_definitions` section, it will generate this error below:
```
│ Error: creating ECS Task Definition (my-service): InvalidParameter: 1 validation error(s) found.
│ - missing required field, RegisterTaskDefinitionInput.ContainerDefinitions[0].LogConfiguration.LogDriver.
│ 
│ 
│   with module.ecs.module.service["my-container"].aws_ecs_task_definition.this[0],
│   on ../../modules/aws-compute-ecs/modules/service/main.tf line 608, in resource "aws_ecs_task_definition" "this":
│  608: resource "aws_ecs_task_definition" "this" {
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This behavior happens because in the planning phase the `logConfiguration` is computed as `{}`, which is an invalid configuration when posting on AWS API.
My `plan` of a just imported resource is:
```
  # module.ecs.module.service["my-service"].aws_ecs_task_definition.this[0] must be replaced
+/- resource "aws_ecs_task_definition" "this" {
      ~ arn                      = "arn:aws:ecs:us-east-1:1234567891011:task-definition/my-service-definition:20" -> (known after apply)
      ~ arn_without_revision     = "arn:aws:ecs:us-east-1:1234567891011:task-definition/my-service-definition" -> (known after apply)
      ~ container_definitions    = jsonencode(
          ~ [
              ~ {
                  + logConfiguration  = {}
                  - mountPoints       = []
                    name              = "worker"
                  - portMappings      = []
                  - volumesFrom       = []
                    # (7 unchanged attributes hidden)
                },
            ] # forces replacement
        )
```

And this is computed this way because of a `merge()`:
```
log_configuration = merge(
    { for k, v in {
      logDriver = "awslogs",
      options = {
        awslogs-region        = data.aws_region.current.name,
        awslogs-group         = try(aws_cloudwatch_log_group.this[0].name, ""),
        awslogs-stream-prefix = "ecs"
      },
    } : k => v if var.enable_cloudwatch_logging },
    var.log_configuration
  )
```

In the console, if all parameters to merge are null or empty, the result is an empty object:
```
> merge({}, null)
{}
> merge(null, null)
{}
> merge({}, {a = "A"})
{
  "a" = "A"
}
> length(merge({}, {a = "A"}))
1
```


## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No breaking change

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
