### PR TITLE
feat: Add ignore_container_definitions_changes variable

### DIFF
--- a/modules/service/variables.tf
+++ b/modules/service/variables.tf
@@ -274,6 +274,12 @@ variable "container_definition_defaults" {
   default     = {}
 }
 
+variable "ignore_container_definitions_changes" {
+  description = "Whether changes to container_definitions should be ignored, beyond initially created. This is useful when an external service is used to update image revision."
+  type        = bool
+  default     = false
+}
+
 variable "cpu" {
   description = "Number of cpu units used by the task. If the `requires_compatibilities` is `FARGATE` this field is required"
   type        = number


### PR DESCRIPTION
to task_definition, to allow external update to container definitions.

## Description

Add `ignore_container_definitions_changes` variable to allow to ignore change in `container_definitions` attribute, after initially created.

## Motivation and Context

This variable is useful, for example, when a external service is used for updating Docker image revision defined in container definition.

## Breaking Changes

No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] This is deployed and tested in an internal production™ cluster.