### PR TITLE
Made CPU parameter optional, added more parameters to the EC2 example

### DIFF
--- a/examples/ec2-autoscaling/main.tf
+++ b/examples/ec2-autoscaling/main.tf
@@ -93,6 +93,13 @@ module "ecs_service" {
     }
   }
 
+  # hard task memory limit
+  # memory = 4096
+
+  # when cpu is specified, it is used for scheduling and also becomes a hard limit on the task.
+  # when missing, the task can consume any available CPU resources on the instance.
+  # cpu = 1024
+
   volume = {
     my-vol = {}
   }
@@ -101,6 +108,15 @@ module "ecs_service" {
   container_definitions = {
     (local.container_name) = {
       image = "public.ecr.aws/ecs-sample-image/amazon-ecs-sample:latest"
+
+
+      # cpu                = 256
+
+      # hard limit on the running tasks, may be omitted if memory_reservation is specified
+      # memory = 4096
+
+      # (optional) soft limit used for scheduling, if omitted the hard memory limit will also be used for scheduling
+      memory_reservation = 1024
       port_mappings = [
         {
           name          = local.container_name

--- a/modules/service/variables.tf
+++ b/modules/service/variables.tf
@@ -277,7 +277,7 @@ variable "container_definition_defaults" {
 variable "cpu" {
   description = "Number of cpu units used by the task. If the `requires_compatibilities` is `FARGATE` this field is required"
   type        = number
-  default     = 1024
+  default     = null
 }
 
 variable "ephemeral_storage" {


### PR DESCRIPTION
## Description
1. make the `cpu` parameter optional, instead of passing 1024 when missing. 
2. add more examples on how to use the memory and cpu parameters to the ec2-autoscaling example.


## Motivation and Context

1. is important because on EC2 the missing `cpu` parameter means the task can expand to occupy the entire host's CPU and is ignored by the ECS scheduler. This may be desirable in some situations, for example when scheduling tasks only based on memory and allowing them to coexist on the same host and consume the CPU freely as they need it.

2. intends to clarify the behavior I mentioned above. See this [blog](https://aws.amazon.com/blogs/containers/how-amazon-ecs-manages-cpu-and-memory-resources/) for more details on these parameters.

## Breaking Changes
none

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
I tried to run `pre-commit run -a` after committing (wasn't aware it's required) and getting an error.
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
