### PR TITLE
Correction of generation task role permissions

### DIFF
--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -794,6 +794,7 @@ data "aws_iam_policy_document" "task_exec" {
     actions = [
       "logs:CreateLogStream",
       "logs:PutLogEvents",
+      "logs:CreateLogGroup"
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
## Description
We have a problem on tasks that need Cloudwatch log group. The tasks can't start because this lack of permission on creating Log Group.

## Motivation and Context
Solve this problem. The policy is injected directly on the Module, so we can't change this on creation.
ResourceInitializationError: failed to validate logger args: create stream has been retried 1 times: failed to create Cloudwatch log group: AccessDeniedException: User: arn:aws:sts::xxxxxxxxxxx:assumed-role/xxxxxxxxx-20230829123820229200000006/82efd840a4194b4f9567a2fcefaed1cb is not authorized to perform: logs:CreateLogGroup on resource: arn:aws:logs:us-east-1:xxxxxxxxxx:log-group:/ecs/xxxxxxxxxxxx:log-stream: because no identity-based policy allows the logs:CreateLogGroup action status code: 400, request id: f44dd3f1-de3b-4246-ba41-ac7b2f813280 : exit status 1

## Breaking Changes
I think no, but I didn't test all functionalities.

## How Has This Been Tested?
When I created services inside the ECS Cluster using this module, the tasks can't start because they need this permission that don't exist inside the module.
