### PR TITLE
feat: Add the external resource equivalents to the outputs as the fallback value

### DIFF
--- a/modules/service/outputs.tf
+++ b/modules/service/outputs.tf
@@ -23,7 +23,7 @@ output "iam_role_name" {
 
 output "iam_role_arn" {
   description = "Service IAM role ARN"
-  value       = try(aws_iam_role.service[0].arn, null)
+  value       = try(aws_iam_role.service[0].arn, var.iam_role_arn)
 }
 
 output "iam_role_unique_id" {
@@ -46,7 +46,7 @@ output "container_definitions" {
 
 output "task_definition_arn" {
   description = "Full ARN of the Task Definition (including both `family` and `revision`)"
-  value       = try(aws_ecs_task_definition.this[0].arn, null)
+  value       = try(aws_ecs_task_definition.this[0].arn, var.task_definition_arn)
 }
 
 output "task_definition_revision" {
@@ -71,7 +71,7 @@ output "task_exec_iam_role_name" {
 
 output "task_exec_iam_role_arn" {
   description = "Task execution IAM role ARN"
-  value       = try(aws_iam_role.task_exec[0].arn, null)
+  value       = try(aws_iam_role.task_exec[0].arn, var.task_exec_iam_role_arn)
 }
 
 output "task_exec_iam_role_unique_id" {
@@ -91,7 +91,7 @@ output "tasks_iam_role_name" {
 
 output "tasks_iam_role_arn" {
   description = "Tasks IAM role ARN"
-  value       = try(aws_iam_role.tasks[0].arn, null)
+  value       = try(aws_iam_role.tasks[0].arn, var.tasks_iam_role_arn)
 }
 
 output "tasks_iam_role_unique_id" {


### PR DESCRIPTION
## Description
- Add the external resource equivalents to the outputs as the fallback value

## Motivation and Context
- When chaining/embedding this module, its easier if the ARNs of resources created outside of the module that are used in place of what the module would create are provided in the outputs. 

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
