### PR TITLE
fix: Add missing tag variable in autoscaling target resource

### DIFF
--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -522,7 +522,7 @@ resource "aws_iam_role_policy_attachment" "service" {
 module "container_definition" {
   source = "../container-definition"
 
-  for_each = { for k, v in var.container_definitions : k => v if local.create_task_definition && try(v.create, true)}
+  for_each = { for k, v in var.container_definitions : k => v if local.create_task_definition && try(v.create, true) }
 
   operating_system_family = try(var.runtime_platform.operating_system_family, "LINUX")
 
@@ -1202,6 +1202,7 @@ resource "aws_appautoscaling_target" "this" {
   resource_id        = "service/${local.cluster_name}/${try(aws_ecs_service.this[0].name, aws_ecs_service.ignore_task_definition[0].name)}"
   scalable_dimension = "ecs:service:DesiredCount"
   service_namespace  = "ecs"
+  tags               = var.tags
 }
 
 resource "aws_appautoscaling_policy" "this" {


### PR DESCRIPTION
## Description
Add the `tags`variable into the `aws_appautoscaling_target`. 


## Motivation and Context
I'm using this module to setup an ECS Service and our checkov complained about missing tags in the `aws_appautoscaling_target`. This PR has the goal to add the tags to this resource.

## Breaking Changes
None. 

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
