### PR TITLE
fix: Allow setting `linux_parameters` without inconsistent left/right error

### DIFF
--- a/examples/fargate/main.tf
+++ b/examples/fargate/main.tf
@@ -111,6 +111,15 @@ module "ecs_service" {
           log-driver-buffer-limit = "2097152"
         }
       }
+
+      linux_parameters = {
+        capabilities = {
+          drop = [
+            "NET_RAW"
+          ]
+        }
+      }
+
       memory_reservation = 100
     }
   }

--- a/modules/container-definition/main.tf
+++ b/modules/container-definition/main.tf
@@ -17,7 +17,7 @@ locals {
     var.log_configuration
   )
 
-  linux_parameters = var.enable_execute_command ? merge({ "initProcessEnabled" : true }, var.linux_parameters) : var.linux_parameters
+  linux_parameters = var.enable_execute_command ? merge({ "initProcessEnabled" : true }, var.linux_parameters) : merge({ "initProcessEnabled" : false }, var.linux_parameters)
 
   definition = {
     command                = length(var.command) > 0 ? var.command : null


### PR DESCRIPTION
## Description
- Allow setting `linux_parameters` without inconsistent left/right error

## Motivation and Context
- Resolves #134

## Breaking Changes
- No

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request