### PR TITLE
docs: Fix description of how autoscaling min and max are set in services

### DIFF
--- a/modules/service/README.md
+++ b/modules/service/README.md
@@ -3,7 +3,8 @@
 Configuration in this directory creates an Amazon ECS Service and associated resources.
 
 Some notable configurations to be aware of when using this module:
-1. `desired_count`/`scale` are not the intended way of setting the number of tasks to run. Instead, use `autoscaling_min_capacity`/`autoscaling_max_capacity` to set the number of tasks to run. Note that the autoscaling definition will select the minimum of `autoscaling_min_capacity` and `desired_count` as the minimum number of tasks to run, so you need to ensure that `desired_count` is greater than or equal to `autoscaling_min_capacity` if you intend to use autoscaling.
+1. `desired_count`/`scale` are not the intended way of setting the number of tasks to run. Instead, use `autoscaling_min_capacity`/`autoscaling_max_capacity` to set the number of tasks to run. 
+- **Note:** The autoscaling definition will prefer `desired_count` over either of those two autoscaling capacity values.  If `desired_count` is less than `autoscaling_min_capacity`, it will use the `desired_count` value as the minimum autoscaling target, and same with the `autoscaling_max_capacity` variable.
 2. The default configuration is intended for `FARGATE` use
 
 For more details see the [design doc](https://github.com/terraform-aws-modules/terraform-aws-ecs/blob/master/docs/README.md)

--- a/modules/service/README.md
+++ b/modules/service/README.md
@@ -3,7 +3,7 @@
 Configuration in this directory creates an Amazon ECS Service and associated resources.
 
 Some notable configurations to be aware of when using this module:
-1. `desired_count`/`scale` is always ignored; the module is designed to utilize autoscaling by default (though it can be disabled)
+1. `desired_count`/`scale` are not the intended way of setting the number of tasks to run. Instead, use `autoscaling_min_capacity`/`autoscaling_max_capacity` to set the number of tasks to run. Note that the autoscaling definition will select the minimum of `autoscaling_min_capacity` and `desired_count` as the minimum number of tasks to run, so you need to ensure that `desired_count` is greater than or equal to `autoscaling_min_capacity` if you intend to use autoscaling.
 2. The default configuration is intended for `FARGATE` use
 
 For more details see the [design doc](https://github.com/terraform-aws-modules/terraform-aws-ecs/blob/master/docs/README.md)


### PR DESCRIPTION
## Description
This PR updates the docs to accurately reflect how the `desired_count` variable affects the autoscaling definition in the services module.  I am not sure of the ramifications of changing the functionality to reflect the docs, so I instead changed the docs to reflect the functionality.

## Motivation and Context
I was trying to get the task count configured in some stuff I'm working on, and I found that the docs state that `desired_count` is ignored, however that variable is used when setting the `min_capacity` and `max_capacity` values in the `aws_appautoscaling_target` resource.  I spent a good chunk of time trying to figure out what I was doing wrong before I dug through the source code and found the issue.

## Breaking Changes
None

## How Has This Been Tested?
No functional changes - just documentation