### PR TITLE
fix: Make default variables partition insensitive

### DIFF
--- a/modules/service/variables.tf
+++ b/modules/service/variables.tf
@@ -435,13 +435,13 @@ variable "create_task_exec_policy" {
 variable "task_exec_ssm_param_arns" {
   description = "List of SSM parameter ARNs the task execution role will be permitted to get/read"
   type        = list(string)
-  default     = ["arn:aws:ssm:*:*:parameter/*"]
+  default     = ["arn:${data.aws_partition.current.partition}:ssm:*:*:parameter/*"]
 }
 
 variable "task_exec_secret_arns" {
   description = "List of SecretsManager secret ARNs the task execution role will be permitted to get/read"
   type        = list(string)
-  default     = ["arn:aws:secretsmanager:*:*:secret:*"]
+  default     = ["arn:${data.aws_partition.current.partition}:secretsmanager:*:*:secret:*"]
 }
 
 variable "task_exec_iam_statements" {


### PR DESCRIPTION
## Description
In order to allow safe deployment to all parititons of AWS, take advantage of the existing partition data source to populate the value of default variables.

## Motivation and Context
Fixes #142

## How Has This Been Tested?
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
