### PR TITLE
fix: Adding missing permissions in the ECS service module

### DIFF
--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -795,6 +795,7 @@ data "aws_iam_policy_document" "task_exec" {
     actions = [
       "logs:CreateLogStream",
       "logs:PutLogEvents",
+      "logs:CreateLogGroup",
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
## Description
ECS Cluster tasks can't start because this lack of permission on creating Log Group.

## Motivation and Context
This fixes an error where a task that is started is allowed to create the AWS CloudWatch log group it needs to log too.

ResourceInitializationError: failed to validate logger args: create stream has been retried 1 times: failed to create Cloudwatch log group: AccessDeniedException: User: arn:aws:sts::xxxxxxxxxxx:assumed-role/xxxxxxxxx-idnumber00000xxxxx/uuid is not authorized to perform: logs:CreateLogGroup on resource: arn:aws:logs:us-east-1:xxxxxxxxxx:log-group:/ecs/xxxxxxxxxxxx:log-stream: because no identity-based policy allows the logs:CreateLogGroup action status code: 400, request id: xxxxxxxx-xxxxx-xxxxx-xxxxx-xxxxxxxxxxxx : exit status 1

## Breaking Changes
It should not break any backwards compatibility, 

## How Has This Been Tested?
This was deployed to a Dev environment, the task failed to start up.
In the module in the .terraform folder I added the missing permission, re-ran the terraform apply which updated the ECS Role with the correct permission and the tasks started successfully.

I then ran a terraform destroy to remove everything, removed the .terraform folder and ran terraform apply again and got the same error as above. re-applied the above test steps and it succeeded

