### PR TITLE
fix: Adding a `health_check` generates a new task definition revision on every `terraform apply`

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -69,6 +69,11 @@ module "ecs" {
           memory    = 1024
           essential = true
           image     = "public.ecr.aws/aws-containers/ecsdemo-frontend:776fd50"
+
+          health_check = {
+            command = ["CMD-SHELL", "curl -f http://localhost:${local.container_port}/health || exit 1"]
+          }
+
           port_mappings = [
             {
               name          = local.container_name

--- a/modules/container-definition/main.tf
+++ b/modules/container-definition/main.tf
@@ -21,8 +21,8 @@ locals {
 
   health_check = length(var.health_check) > 0 ? merge({
     interval = 30,
-    retries = 3,
-    timeout = 5
+    retries  = 3,
+    timeout  = 5
   }, var.health_check) : null
 
   definition = {

--- a/modules/container-definition/main.tf
+++ b/modules/container-definition/main.tf
@@ -19,6 +19,12 @@ locals {
 
   linux_parameters = var.enable_execute_command ? merge({ "initProcessEnabled" : true }, var.linux_parameters) : merge({ "initProcessEnabled" : false }, var.linux_parameters)
 
+  health_check = length(var.health_check) > 0 ? merge({
+    interval = 30,
+    retries = 3,
+    timeout = 5
+  }, var.health_check) : null
+
   definition = {
     command                = length(var.command) > 0 ? var.command : null
     cpu                    = var.cpu
@@ -34,7 +40,7 @@ locals {
     essential              = var.essential
     extraHosts             = local.is_not_windows && length(var.extra_hosts) > 0 ? var.extra_hosts : null
     firelensConfiguration  = length(var.firelens_configuration) > 0 ? var.firelens_configuration : null
-    healthCheck            = length(var.health_check) > 0 ? var.health_check : null
+    healthCheck            = local.health_check
     hostname               = var.hostname
     image                  = var.image
     interactive            = var.interactive


### PR DESCRIPTION
## Description

The current PR explicitly adds the `interval`,`retries`, and `timeout` parameters to the `healthCheck` block when they are not supplied to prevent mismatches between the Terraform state and AWS, which results in a new task revision during each `terraform apply`.

**Note:** The default values are taken from the official [documentation](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_HealthCheck.html#API_HealthCheck_Contents).

## Motivation and Context

- Resolves #148 

## Breaking Changes
No breaking changes

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
