### PR TITLE
feat: Support `managed_draining` argument at `aws_ecs_capacity_provider`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,9 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.83.6
+    rev: v1.86.0
     hooks:
       - id: terraform_fmt
       - id: terraform_wrapper_module_for_each
-      - id: terraform_validate
       - id: terraform_docs
         args:
           - '--args=--lockfile=false'
@@ -23,8 +22,10 @@ repos:
           - '--args=--only=terraform_required_providers'
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
+      - id: terraform_validate
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
+      - id: trailing-whitespace

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ module "ecs" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.66.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.34.0 |
 
 ## Providers
 

--- a/README.md
+++ b/README.md
@@ -159,8 +159,8 @@ module "ecs" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.34.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.34 |
 
 ## Providers
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -27,13 +27,13 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.66.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.34.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.66.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.34.0 |
 
 ## Modules
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -26,14 +26,14 @@ Note that this example may create resources which will incur monetary charges on
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.34.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.34 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.34.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.34 |
 
 ## Modules
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34.0"
+      version = ">= 5.34"
     }
   }
 }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.66.1"
+      version = ">= 5.34.0"
     }
   }
 }

--- a/examples/ec2-autoscaling/README.md
+++ b/examples/ec2-autoscaling/README.md
@@ -27,13 +27,13 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.66.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.34.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.66.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.34.0 |
 
 ## Modules
 

--- a/examples/ec2-autoscaling/README.md
+++ b/examples/ec2-autoscaling/README.md
@@ -26,14 +26,14 @@ Note that this example may create resources which will incur monetary charges on
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.34.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.34 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.34.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.34 |
 
 ## Modules
 

--- a/examples/ec2-autoscaling/main.tf
+++ b/examples/ec2-autoscaling/main.tf
@@ -36,6 +36,7 @@ module "ecs_cluster" {
     # On-demand instances
     ex_1 = {
       auto_scaling_group_arn         = module.autoscaling["ex_1"].autoscaling_group_arn
+      managed_draining               = "ENABLED"
       managed_termination_protection = "ENABLED"
 
       managed_scaling = {
@@ -53,6 +54,7 @@ module "ecs_cluster" {
     # Spot instances
     ex_2 = {
       auto_scaling_group_arn         = module.autoscaling["ex_2"].autoscaling_group_arn
+      managed_draining               = "ENABLED"
       managed_termination_protection = "ENABLED"
 
       managed_scaling = {

--- a/examples/ec2-autoscaling/versions.tf
+++ b/examples/ec2-autoscaling/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34.0"
+      version = ">= 5.34"
     }
   }
 }

--- a/examples/ec2-autoscaling/versions.tf
+++ b/examples/ec2-autoscaling/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.66.1"
+      version = ">= 5.34.0"
     }
   }
 }

--- a/examples/fargate/README.md
+++ b/examples/fargate/README.md
@@ -27,13 +27,13 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.66.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.34.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.66.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.34.0 |
 
 ## Modules
 

--- a/examples/fargate/README.md
+++ b/examples/fargate/README.md
@@ -26,14 +26,14 @@ Note that this example may create resources which will incur monetary charges on
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.34.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.34 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.34.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.34 |
 
 ## Modules
 

--- a/examples/fargate/versions.tf
+++ b/examples/fargate/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34.0"
+      version = ">= 5.34"
     }
   }
 }

--- a/examples/fargate/versions.tf
+++ b/examples/fargate/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.66.1"
+      version = ">= 5.34.0"
     }
   }
 }

--- a/modules/cluster/README.md
+++ b/modules/cluster/README.md
@@ -137,13 +137,13 @@ module "ecs_cluster" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.66.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.34.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.66.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.34.0 |
 
 ## Modules
 

--- a/modules/cluster/README.md
+++ b/modules/cluster/README.md
@@ -136,14 +136,14 @@ module "ecs_cluster" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.34.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.34 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.34.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.34 |
 
 ## Modules
 

--- a/modules/cluster/README.md
+++ b/modules/cluster/README.md
@@ -70,6 +70,7 @@ module "ecs_cluster" {
   autoscaling_capacity_providers = {
     one = {
       auto_scaling_group_arn         = "arn:aws:autoscaling:eu-west-1:012345678901:autoScalingGroup:08419a61:autoScalingGroupName/ecs-ec2-one-20220603194933774300000011"
+      managed_draining               = "DISABLED"
       managed_termination_protection = "ENABLED"
 
       managed_scaling = {
@@ -86,6 +87,7 @@ module "ecs_cluster" {
     }
     two = {
       auto_scaling_group_arn         = "arn:aws:autoscaling:eu-west-1:012345678901:autoScalingGroup:08419a61:autoScalingGroupName/ecs-ec2-two-20220603194933774300000022"
+      managed_draining               = "ENABLED"
       managed_termination_protection = "ENABLED"
 
       managed_scaling = {

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -152,6 +152,7 @@ resource "aws_ecs_capacity_provider" "this" {
 
   auto_scaling_group_provider {
     auto_scaling_group_arn = each.value.auto_scaling_group_arn
+    managed_draining       = try(each.value.managed_draining, "ENABLED")
     # When you use managed termination protection, you must also use managed scaling otherwise managed termination protection won't work
     managed_termination_protection = length(try([each.value.managed_scaling], [])) == 0 ? "DISABLED" : try(each.value.managed_termination_protection, null)
 

--- a/modules/cluster/versions.tf
+++ b/modules/cluster/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34.0"
+      version = ">= 5.34"
     }
   }
 }

--- a/modules/cluster/versions.tf
+++ b/modules/cluster/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.66.1"
+      version = ">= 5.34.0"
     }
   }
 }

--- a/modules/container-definition/README.md
+++ b/modules/container-definition/README.md
@@ -115,14 +115,14 @@ module "example_ecs_container_definition" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.34.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.34 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.34.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.34 |
 
 ## Modules
 

--- a/modules/container-definition/README.md
+++ b/modules/container-definition/README.md
@@ -116,13 +116,13 @@ module "example_ecs_container_definition" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.66.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.34.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.66.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.34.0 |
 
 ## Modules
 

--- a/modules/container-definition/versions.tf
+++ b/modules/container-definition/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34.0"
+      version = ">= 5.34"
     }
   }
 }

--- a/modules/container-definition/versions.tf
+++ b/modules/container-definition/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.66.1"
+      version = ">= 5.34.0"
     }
   }
 }

--- a/modules/service/README.md
+++ b/modules/service/README.md
@@ -167,13 +167,13 @@ module "ecs_service" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.66.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.34.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.66.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.34.0 |
 
 ## Modules
 

--- a/modules/service/README.md
+++ b/modules/service/README.md
@@ -166,14 +166,14 @@ module "ecs_service" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.34.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.34 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.34.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.34 |
 
 ## Modules
 

--- a/modules/service/versions.tf
+++ b/modules/service/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34.0"
+      version = ">= 5.34"
     }
   }
 }

--- a/modules/service/versions.tf
+++ b/modules/service/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.66.1"
+      version = ">= 5.34.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34.0"
+      version = ">= 5.34"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.66.1"
+      version = ">= 5.34.0"
     }
   }
 }


### PR DESCRIPTION
## Description
Support of `managed_draining` argument at `auto_scaling_group_provider` block of  `aws_ecs_capacity_provider` resource introduced by
- [v5.34.0 of the Terraform AWS Provider](https://github.com/hashicorp/terraform-provider-aws/blob/v5.34.0/CHANGELOG.md).
- https://github.com/hashicorp/terraform-provider-aws/pull/35421

## Motivation and Context
- Resolves https://github.com/terraform-aws-modules/terraform-aws-ecs/issues/156

## Breaking Changes

:warning: Minimal required AWS provider version is `>=5.34.0`

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
For already created ECS ASG capacity provider:
- config
```HCL
module "ecs_cluster" {
  source = "../../../../../../open-source/terraform-aws-ecs/modules/cluster"

  cluster_name = local.ecs_cluster_name

  # Capacity provider - autoscaling groups
  default_capacity_provider_use_fargate = false

  autoscaling_capacity_providers = {
    for k, v in module.asg_ecs : "${local.ecs_cluster_name}-${k}" => {
      auto_scaling_group_arn         = v.autoscaling_group_arn
      managed_draining               = "ENABLED"
# ....
}
```

- Terraform running
```bash
$ terraform init -upgrade && terraform plan
...
- Installing hashicorp/aws v5.34.0...
- Installed hashicorp/aws v5.34.0 (signed by HashiCorp)
...


  # module.ecs_cluster.aws_ecs_capacity_provider.this["xxxxx"] will be updated in-place
  ~ resource "aws_ecs_capacity_provider" "this" {
        id       = "arn:aws:ecs:xxx:xxx:capacity-provider/xxxxx"
        name     = "xxxx"

        # (2 unchanged attributes hidden)

      ~ auto_scaling_group_provider {
          ~ managed_draining               = "DISABLED" -> "ENABLED"
            # (2 unchanged attributes hidden)

            # (1 unchanged block hidden)
        }
    }
```
- [x] I have executed `pre-commit run -a` on my pull request
```
✗ pre-commit run -a
Terraform fmt............................................................Passed
Terraform wrapper with for_each in module................................Passed
Terraform validate.......................................................Passed
Terraform docs...........................................................Passed
Terraform validate with tflint...........................................Passed
check for merge conflicts................................................Passed
fix end of files.........................................................Passed
```


