### PR TITLE
feat: Add support for cluster and container definition custom CloudWatch log group names

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ No resources.
 |------|-------------|------|---------|:--------:|
 | <a name="input_autoscaling_capacity_providers"></a> [autoscaling\_capacity\_providers](#input\_autoscaling\_capacity\_providers) | Map of autoscaling capacity provider definitions to create for the cluster | `any` | `{}` | no |
 | <a name="input_cloudwatch_log_group_kms_key_id"></a> [cloudwatch\_log\_group\_kms\_key\_id](#input\_cloudwatch\_log\_group\_kms\_key\_id) | If a KMS Key ARN is set, this key will be used to encrypt the corresponding log group. Please be sure that the KMS Key has an appropriate key policy (https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html) | `string` | `null` | no |
+| <a name="input_cloudwatch_log_group_name"></a> [cloudwatch\_log\_group\_name](#input\_cloudwatch\_log\_group\_name) | Custom name of CloudWatch Log Group for ECS cluster | `string` | `null` | no |
 | <a name="input_cloudwatch_log_group_retention_in_days"></a> [cloudwatch\_log\_group\_retention\_in\_days](#input\_cloudwatch\_log\_group\_retention\_in\_days) | Number of days to retain log events | `number` | `90` | no |
 | <a name="input_cloudwatch_log_group_tags"></a> [cloudwatch\_log\_group\_tags](#input\_cloudwatch\_log\_group\_tags) | A map of additional tags to add to the log group created | `map(string)` | `{}` | no |
 | <a name="input_cluster_configuration"></a> [cluster\_configuration](#input\_cluster\_configuration) | The execute command configuration for the cluster | `any` | `{}` | no |
@@ -214,8 +215,8 @@ No resources.
 | Name | Description |
 |------|-------------|
 | <a name="output_autoscaling_capacity_providers"></a> [autoscaling\_capacity\_providers](#output\_autoscaling\_capacity\_providers) | Map of autoscaling capacity providers created and their attributes |
-| <a name="output_cloudwatch_log_group_arn"></a> [cloudwatch\_log\_group\_arn](#output\_cloudwatch\_log\_group\_arn) | Arn of cloudwatch log group created |
-| <a name="output_cloudwatch_log_group_name"></a> [cloudwatch\_log\_group\_name](#output\_cloudwatch\_log\_group\_name) | Name of cloudwatch log group created |
+| <a name="output_cloudwatch_log_group_arn"></a> [cloudwatch\_log\_group\_arn](#output\_cloudwatch\_log\_group\_arn) | ARN of CloudWatch log group created |
+| <a name="output_cloudwatch_log_group_name"></a> [cloudwatch\_log\_group\_name](#output\_cloudwatch\_log\_group\_name) | Name of CloudWatch log group created |
 | <a name="output_cluster_arn"></a> [cluster\_arn](#output\_cluster\_arn) | ARN that identifies the cluster |
 | <a name="output_cluster_capacity_providers"></a> [cluster\_capacity\_providers](#output\_cluster\_capacity\_providers) | Map of cluster capacity providers attributes |
 | <a name="output_cluster_id"></a> [cluster\_id](#output\_cluster\_id) | ID that identifies the cluster |

--- a/main.tf
+++ b/main.tf
@@ -15,8 +15,9 @@ module "cluster" {
 
   # Cluster Cloudwatch log group
   create_cloudwatch_log_group            = var.create_cloudwatch_log_group
-  cloudwatch_log_group_retention_in_days = var.cloudwatch_log_group_retention_in_days
   cloudwatch_log_group_kms_key_id        = var.cloudwatch_log_group_kms_key_id
+  cloudwatch_log_group_name              = var.cloudwatch_log_group_name
+  cloudwatch_log_group_retention_in_days = var.cloudwatch_log_group_retention_in_days
   cloudwatch_log_group_tags              = var.cloudwatch_log_group_tags
 
   # Cluster capacity providers

--- a/main.tf
+++ b/main.tf
@@ -15,9 +15,9 @@ module "cluster" {
 
   # Cluster Cloudwatch log group
   create_cloudwatch_log_group            = var.create_cloudwatch_log_group
-  cloudwatch_log_group_kms_key_id        = var.cloudwatch_log_group_kms_key_id
   cloudwatch_log_group_name              = var.cloudwatch_log_group_name
   cloudwatch_log_group_retention_in_days = var.cloudwatch_log_group_retention_in_days
+  cloudwatch_log_group_kms_key_id        = var.cloudwatch_log_group_kms_key_id
   cloudwatch_log_group_tags              = var.cloudwatch_log_group_tags
 
   # Cluster capacity providers

--- a/modules/cluster/README.md
+++ b/modules/cluster/README.md
@@ -168,6 +168,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_autoscaling_capacity_providers"></a> [autoscaling\_capacity\_providers](#input\_autoscaling\_capacity\_providers) | Map of autoscaling capacity provider definitions to create for the cluster | `any` | `{}` | no |
 | <a name="input_cloudwatch_log_group_kms_key_id"></a> [cloudwatch\_log\_group\_kms\_key\_id](#input\_cloudwatch\_log\_group\_kms\_key\_id) | If a KMS Key ARN is set, this key will be used to encrypt the corresponding log group. Please be sure that the KMS Key has an appropriate key policy (https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html) | `string` | `null` | no |
+| <a name="input_cloudwatch_log_group_name"></a> [cloudwatch\_log\_group\_name](#input\_cloudwatch\_log\_group\_name) | Custom name of CloudWatch Log Group for ECS cluster | `string` | `null` | no |
 | <a name="input_cloudwatch_log_group_retention_in_days"></a> [cloudwatch\_log\_group\_retention\_in\_days](#input\_cloudwatch\_log\_group\_retention\_in\_days) | Number of days to retain log events | `number` | `90` | no |
 | <a name="input_cloudwatch_log_group_tags"></a> [cloudwatch\_log\_group\_tags](#input\_cloudwatch\_log\_group\_tags) | A map of additional tags to add to the log group created | `map(string)` | `{}` | no |
 | <a name="input_cluster_configuration"></a> [cluster\_configuration](#input\_cluster\_configuration) | The execute command configuration for the cluster | `any` | `{}` | no |
@@ -198,8 +199,8 @@ No modules.
 |------|-------------|
 | <a name="output_arn"></a> [arn](#output\_arn) | ARN that identifies the cluster |
 | <a name="output_autoscaling_capacity_providers"></a> [autoscaling\_capacity\_providers](#output\_autoscaling\_capacity\_providers) | Map of autoscaling capacity providers created and their attributes |
-| <a name="output_cloudwatch_log_group_arn"></a> [cloudwatch\_log\_group\_arn](#output\_cloudwatch\_log\_group\_arn) | Arn of cloudwatch log group created |
-| <a name="output_cloudwatch_log_group_name"></a> [cloudwatch\_log\_group\_name](#output\_cloudwatch\_log\_group\_name) | Name of cloudwatch log group created |
+| <a name="output_cloudwatch_log_group_arn"></a> [cloudwatch\_log\_group\_arn](#output\_cloudwatch\_log\_group\_arn) | ARN of CloudWatch log group created |
+| <a name="output_cloudwatch_log_group_name"></a> [cloudwatch\_log\_group\_name](#output\_cloudwatch\_log\_group\_name) | Name of CloudWatch log group created |
 | <a name="output_cluster_capacity_providers"></a> [cluster\_capacity\_providers](#output\_cluster\_capacity\_providers) | Map of cluster capacity providers attributes |
 | <a name="output_id"></a> [id](#output\_id) | ID that identifies the cluster |
 | <a name="output_name"></a> [name](#output\_name) | Name that identifies the cluster |

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -93,11 +93,10 @@ resource "aws_ecs_cluster" "this" {
 ################################################################################
 # CloudWatch Log Group
 ################################################################################
-
 resource "aws_cloudwatch_log_group" "this" {
   count = var.create && var.create_cloudwatch_log_group ? 1 : 0
 
-  name              = "/aws/ecs/${var.cluster_name}"
+  name              = try(coalesce(var.cloudwatch_log_group_name, "/aws/ecs/${var.cluster_name}"), "")
   retention_in_days = var.cloudwatch_log_group_retention_in_days
   kms_key_id        = var.cloudwatch_log_group_kms_key_id
 

--- a/modules/cluster/outputs.tf
+++ b/modules/cluster/outputs.tf
@@ -22,12 +22,12 @@ output "name" {
 ################################################################################
 
 output "cloudwatch_log_group_name" {
-  description = "Name of cloudwatch log group created"
+  description = "Name of CloudWatch log group created"
   value       = try(aws_cloudwatch_log_group.this[0].name, null)
 }
 
 output "cloudwatch_log_group_arn" {
-  description = "Arn of cloudwatch log group created"
+  description = "ARN of CloudWatch log group created"
   value       = try(aws_cloudwatch_log_group.this[0].arn, null)
 }
 

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -53,12 +53,6 @@ variable "create_cloudwatch_log_group" {
   default     = true
 }
 
-variable "cloudwatch_log_group_kms_key_id" {
-  description = "If a KMS Key ARN is set, this key will be used to encrypt the corresponding log group. Please be sure that the KMS Key has an appropriate key policy (https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html)"
-  type        = string
-  default     = null
-}
-
 variable "cloudwatch_log_group_name" {
   description = "Custom name of CloudWatch Log Group for ECS cluster"
   type        = string
@@ -69,6 +63,12 @@ variable "cloudwatch_log_group_retention_in_days" {
   description = "Number of days to retain log events"
   type        = number
   default     = 90
+}
+
+variable "cloudwatch_log_group_kms_key_id" {
+  description = "If a KMS Key ARN is set, this key will be used to encrypt the corresponding log group. Please be sure that the KMS Key has an appropriate key policy (https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html)"
+  type        = string
+  default     = null
 }
 
 variable "cloudwatch_log_group_tags" {

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -53,16 +53,22 @@ variable "create_cloudwatch_log_group" {
   default     = true
 }
 
-variable "cloudwatch_log_group_retention_in_days" {
-  description = "Number of days to retain log events"
-  type        = number
-  default     = 90
-}
-
 variable "cloudwatch_log_group_kms_key_id" {
   description = "If a KMS Key ARN is set, this key will be used to encrypt the corresponding log group. Please be sure that the KMS Key has an appropriate key policy (https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html)"
   type        = string
   default     = null
+}
+
+variable "cloudwatch_log_group_name" {
+  description = "Custom name of CloudWatch Log Group for ECS cluster"
+  type        = string
+  default     = null
+}
+
+variable "cloudwatch_log_group_retention_in_days" {
+  description = "Number of days to retain log events"
+  type        = number
+  default     = 90
 }
 
 variable "cloudwatch_log_group_tags" {

--- a/modules/container-definition/README.md
+++ b/modules/container-definition/README.md
@@ -140,6 +140,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_cloudwatch_log_group_kms_key_id"></a> [cloudwatch\_log\_group\_kms\_key\_id](#input\_cloudwatch\_log\_group\_kms\_key\_id) | If a KMS Key ARN is set, this key will be used to encrypt the corresponding log group. Please be sure that the KMS Key has an appropriate key policy (https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html) | `string` | `null` | no |
+| <a name="input_cloudwatch_log_group_name"></a> [cloudwatch\_log\_group\_name](#input\_cloudwatch\_log\_group\_name) | Custom name of CloudWatch log group for a service associated with the container definition | `string` | `null` | no |
 | <a name="input_cloudwatch_log_group_retention_in_days"></a> [cloudwatch\_log\_group\_retention\_in\_days](#input\_cloudwatch\_log\_group\_retention\_in\_days) | Number of days to retain log events. Default is 30 days | `number` | `30` | no |
 | <a name="input_cloudwatch_log_group_use_name_prefix"></a> [cloudwatch\_log\_group\_use\_name\_prefix](#input\_cloudwatch\_log\_group\_use\_name\_prefix) | Determines whether the log group name should be used as a prefix | `bool` | `false` | no |
 | <a name="input_command"></a> [command](#input\_command) | The command that's passed to the container | `list(string)` | `[]` | no |
@@ -192,8 +193,8 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_cloudwatch_log_group_arn"></a> [cloudwatch\_log\_group\_arn](#output\_cloudwatch\_log\_group\_arn) | Arn of cloudwatch log group created |
-| <a name="output_cloudwatch_log_group_name"></a> [cloudwatch\_log\_group\_name](#output\_cloudwatch\_log\_group\_name) | Name of cloudwatch log group created |
+| <a name="output_cloudwatch_log_group_arn"></a> [cloudwatch\_log\_group\_arn](#output\_cloudwatch\_log\_group\_arn) | ARN of CloudWatch log group created |
+| <a name="output_cloudwatch_log_group_name"></a> [cloudwatch\_log\_group\_name](#output\_cloudwatch\_log\_group\_name) | Name of CloudWatch log group created |
 | <a name="output_container_definition"></a> [container\_definition](#output\_container\_definition) | Container definition |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/modules/container-definition/main.tf
+++ b/modules/container-definition/main.tf
@@ -3,7 +3,7 @@ data "aws_region" "current" {}
 locals {
   is_not_windows = contains(["LINUX"], var.operating_system_family)
 
-  log_group_name = "/aws/ecs/${var.service}/${var.name}"
+  log_group_name = try(coalesce(var.cloudwatch_log_group_name, "/aws/ecs/${var.service}/${var.name}"), "")
 
   log_configuration = merge(
     { for k, v in {

--- a/modules/container-definition/outputs.tf
+++ b/modules/container-definition/outputs.tf
@@ -12,11 +12,11 @@ output "container_definition" {
 ################################################################################
 
 output "cloudwatch_log_group_name" {
-  description = "Name of cloudwatch log group created"
+  description = "Name of CloudWatch log group created"
   value       = try(aws_cloudwatch_log_group.this[0].name, null)
 }
 
 output "cloudwatch_log_group_arn" {
-  description = "Arn of cloudwatch log group created"
+  description = "ARN of CloudWatch log group created"
   value       = try(aws_cloudwatch_log_group.this[0].arn, null)
 }

--- a/modules/container-definition/variables.tf
+++ b/modules/container-definition/variables.tf
@@ -292,6 +292,12 @@ variable "create_cloudwatch_log_group" {
   default     = true
 }
 
+variable "cloudwatch_log_group_name" {
+  description = "Custom name of CloudWatch log group for a service associated with the container definition"
+  type        = string
+  default     = null
+}
+
 variable "cloudwatch_log_group_use_name_prefix" {
   description = "Determines whether the log group name should be used as a prefix"
   type        = bool

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,12 +18,12 @@ output "cluster_name" {
 }
 
 output "cloudwatch_log_group_name" {
-  description = "Name of cloudwatch log group created"
+  description = "Name of CloudWatch log group created"
   value       = module.cluster.cloudwatch_log_group_name
 }
 
 output "cloudwatch_log_group_arn" {
-  description = "Arn of cloudwatch log group created"
+  description = "ARN of CloudWatch log group created"
   value       = module.cluster.cloudwatch_log_group_arn
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -59,16 +59,22 @@ variable "create_cloudwatch_log_group" {
   default     = true
 }
 
-variable "cloudwatch_log_group_retention_in_days" {
-  description = "Number of days to retain log events"
-  type        = number
-  default     = 90
-}
-
 variable "cloudwatch_log_group_kms_key_id" {
   description = "If a KMS Key ARN is set, this key will be used to encrypt the corresponding log group. Please be sure that the KMS Key has an appropriate key policy (https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html)"
   type        = string
   default     = null
+}
+
+variable "cloudwatch_log_group_name" {
+  description = "Custom name of CloudWatch Log Group for ECS cluster"
+  type        = string
+  default     = null
+}
+
+variable "cloudwatch_log_group_retention_in_days" {
+  description = "Number of days to retain log events"
+  type        = number
+  default     = 90
 }
 
 variable "cloudwatch_log_group_tags" {

--- a/variables.tf
+++ b/variables.tf
@@ -59,12 +59,6 @@ variable "create_cloudwatch_log_group" {
   default     = true
 }
 
-variable "cloudwatch_log_group_kms_key_id" {
-  description = "If a KMS Key ARN is set, this key will be used to encrypt the corresponding log group. Please be sure that the KMS Key has an appropriate key policy (https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html)"
-  type        = string
-  default     = null
-}
-
 variable "cloudwatch_log_group_name" {
   description = "Custom name of CloudWatch Log Group for ECS cluster"
   type        = string
@@ -75,6 +69,12 @@ variable "cloudwatch_log_group_retention_in_days" {
   description = "Number of days to retain log events"
   type        = number
   default     = 90
+}
+
+variable "cloudwatch_log_group_kms_key_id" {
+  description = "If a KMS Key ARN is set, this key will be used to encrypt the corresponding log group. Please be sure that the KMS Key has an appropriate key policy (https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html)"
+  type        = string
+  default     = null
 }
 
 variable "cloudwatch_log_group_tags" {

--- a/wrappers/cluster/main.tf
+++ b/wrappers/cluster/main.tf
@@ -5,6 +5,7 @@ module "wrapper" {
 
   autoscaling_capacity_providers         = try(each.value.autoscaling_capacity_providers, var.defaults.autoscaling_capacity_providers, {})
   cloudwatch_log_group_kms_key_id        = try(each.value.cloudwatch_log_group_kms_key_id, var.defaults.cloudwatch_log_group_kms_key_id, null)
+  cloudwatch_log_group_name              = try(each.value.cloudwatch_log_group_name, var.defaults.cloudwatch_log_group_name, null)
   cloudwatch_log_group_retention_in_days = try(each.value.cloudwatch_log_group_retention_in_days, var.defaults.cloudwatch_log_group_retention_in_days, 90)
   cloudwatch_log_group_tags              = try(each.value.cloudwatch_log_group_tags, var.defaults.cloudwatch_log_group_tags, {})
   cluster_configuration                  = try(each.value.cluster_configuration, var.defaults.cluster_configuration, {})

--- a/wrappers/container-definition/main.tf
+++ b/wrappers/container-definition/main.tf
@@ -4,6 +4,7 @@ module "wrapper" {
   for_each = var.items
 
   cloudwatch_log_group_kms_key_id        = try(each.value.cloudwatch_log_group_kms_key_id, var.defaults.cloudwatch_log_group_kms_key_id, null)
+  cloudwatch_log_group_name              = try(each.value.cloudwatch_log_group_name, var.defaults.cloudwatch_log_group_name, null)
   cloudwatch_log_group_retention_in_days = try(each.value.cloudwatch_log_group_retention_in_days, var.defaults.cloudwatch_log_group_retention_in_days, 30)
   cloudwatch_log_group_use_name_prefix   = try(each.value.cloudwatch_log_group_use_name_prefix, var.defaults.cloudwatch_log_group_use_name_prefix, false)
   command                                = try(each.value.command, var.defaults.command, [])

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -5,6 +5,7 @@ module "wrapper" {
 
   autoscaling_capacity_providers         = try(each.value.autoscaling_capacity_providers, var.defaults.autoscaling_capacity_providers, {})
   cloudwatch_log_group_kms_key_id        = try(each.value.cloudwatch_log_group_kms_key_id, var.defaults.cloudwatch_log_group_kms_key_id, null)
+  cloudwatch_log_group_name              = try(each.value.cloudwatch_log_group_name, var.defaults.cloudwatch_log_group_name, null)
   cloudwatch_log_group_retention_in_days = try(each.value.cloudwatch_log_group_retention_in_days, var.defaults.cloudwatch_log_group_retention_in_days, 90)
   cloudwatch_log_group_tags              = try(each.value.cloudwatch_log_group_tags, var.defaults.cloudwatch_log_group_tags, {})
   cluster_configuration                  = try(each.value.cluster_configuration, var.defaults.cluster_configuration, {})


### PR DESCRIPTION
## Description
The possibility to define a **custom** AWS CloudWatch LogGroup name instead of a pre-defined pattern at the module.

## Motivation and Context
Previously, it was impossible to define the custom name of CW LogGroup while creating a group with the modules.

## Breaking Changes
No.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
#### ECS Cluster Log Group
- config
```HCL
module "ecs_cluster" {
  source = "../../../../../../open-source/terraform-aws-ecs/modules/cluster"
  #  source  = "terraform-aws-modules/ecs/aws//modules//cluster"
  #  version = "~> 5.7"
  # ...
  cloudwatch_log_group_name = "/aws/ecs/custom-cluster-test"
```
- `terraform plan`
```bash
  # module.ecs_cluster.aws_cloudwatch_log_group.this[0] must be replaced
-/+ resource "aws_cloudwatch_log_group" "this" {
      ~ arn               = "arn:aws:logs:xxx:xxx:log-group:/aws/ecs/xxx" -> (known after apply)
...
      ~ name              = "/aws/ecs/xxx" -> "/aws/ecs/custom-cluster-test" # forces replacement
...
    }
```

- config
```HCL
module "ecs_cluster" {
  # ...
  # cloudwatch_log_group_name = "/aws/ecs/custom-cluster-test"
```
- `terraform plan`
```bash
No changes. Your infrastructure matches the configuration.
```

#### ECS Containers' Log Group
- config
```HCL
module "ecs_container_def_custom" {
  source = "../../../../../../open-source/terraform-aws-ecs/modules/container-definition"
  #  source  = "terraform-aws-modules/ecs/aws//modules//container-definition"
  #  version = "~> 5.7"
  # ...
  enable_cloudwatch_logging   = true
  create_cloudwatch_log_group = true
  cloudwatch_log_group_name = "/aws/ecs/test-custom-name"
```
- `terraform plan`
```bash
Terraform will perform the following actions:

  # module.ecs_container_def_custom.aws_cloudwatch_log_group.this[0] will be created
  + resource "aws_cloudwatch_log_group" "this" {
      + arn               = (known after apply)
      + id                = (known after apply)
      + log_group_class   = (known after apply)
      + name              = "/aws/ecs/test-custom-name"
      ...
    }
```

- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
