### PR TITLE
fix: Pass CloudWatch log group name from the service module to the container definition module

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -91,16 +91,18 @@ module "ecs" {
             condition     = "START"
           }]
 
-          enable_cloudwatch_logging = false
+          enable_cloudwatch_logging              = true
+          create_cloudwatch_log_group            = true
+          cloudwatch_log_group_name              = "/aws/ecs/${local.name}/${local.container_name}"
+          cloudwatch_log_group_retention_in_days = 7
+
           log_configuration = {
-            logDriver = "awsfirelens"
+            logDriver = "awslogs"
             options = {
-              Name                    = "firehose"
-              region                  = local.region
-              delivery_stream         = "my-stream"
-              log-driver-buffer-limit = "2097152"
+              awslogs-region = local.region
             }
           }
+
           memory_reservation = 100
         }
       }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -91,18 +91,16 @@ module "ecs" {
             condition     = "START"
           }]
 
-          enable_cloudwatch_logging              = true
-          create_cloudwatch_log_group            = true
-          cloudwatch_log_group_name              = "/aws/ecs/${local.name}/${local.container_name}"
-          cloudwatch_log_group_retention_in_days = 7
-
+          enable_cloudwatch_logging = false
           log_configuration = {
-            logDriver = "awslogs"
+            logDriver = "awsfirelens"
             options = {
-              awslogs-region = local.region
+              Name                    = "firehose"
+              region                  = local.region
+              delivery_stream         = "my-stream"
+              log-driver-buffer-limit = "2097152"
             }
           }
-
           memory_reservation = 100
         }
       }

--- a/examples/ec2-autoscaling/main.tf
+++ b/examples/ec2-autoscaling/main.tf
@@ -120,6 +120,18 @@ module "ecs_service" {
 
       # Example image used requires access to write to root filesystem
       readonly_root_filesystem = false
+
+      enable_cloudwatch_logging              = true
+      create_cloudwatch_log_group            = true
+      cloudwatch_log_group_name              = "/aws/ecs/${local.name}/${local.container_name}"
+      cloudwatch_log_group_retention_in_days = 7
+
+      log_configuration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-region = local.region
+        }
+      }
     }
   }
 

--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -572,6 +572,7 @@ module "container_definition" {
   service                                = var.name
   enable_cloudwatch_logging              = try(each.value.enable_cloudwatch_logging, var.container_definition_defaults.enable_cloudwatch_logging, true)
   create_cloudwatch_log_group            = try(each.value.create_cloudwatch_log_group, var.container_definition_defaults.create_cloudwatch_log_group, true)
+  cloudwatch_log_group_name              = try(each.value.cloudwatch_log_group_name, var.container_definition_defaults.cloudwatch_log_group_name, null)
   cloudwatch_log_group_use_name_prefix   = try(each.value.cloudwatch_log_group_use_name_prefix, var.container_definition_defaults.cloudwatch_log_group_use_name_prefix, false)
   cloudwatch_log_group_retention_in_days = try(each.value.cloudwatch_log_group_retention_in_days, var.container_definition_defaults.cloudwatch_log_group_retention_in_days, 14)
   cloudwatch_log_group_kms_key_id        = try(each.value.cloudwatch_log_group_kms_key_id, var.container_definition_defaults.cloudwatch_log_group_kms_key_id, null)


### PR DESCRIPTION
## Description
Fix the passing of the custom CloudWatch log group name through the `service` module to the  `container-definition` one introduced in https://github.com/terraform-aws-modules/terraform-aws-ecs/pull/160.

## Motivation and Context
To have the ability to pass custom CloudWatch log group name from the `service` module.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request

