### PR TITLE
docs: Fix example as Terraform performs shallow merge of nested maps

### DIFF
--- a/examples/ec2-autoscaling/main.tf
+++ b/examples/ec2-autoscaling/main.tf
@@ -128,9 +128,6 @@ module "ecs_service" {
 
       log_configuration = {
         logDriver = "awslogs"
-        options = {
-          awslogs-region = local.region
-        }
       }
     }
   }


### PR DESCRIPTION
## Description
Fix the example with a custom CloudWatch log group name because `log_configuration.options` override during the merge operation as Terraform doesn't perform a deep merge of nested maps.

Fixes https://github.com/terraform-aws-modules/terraform-aws-ecs/issues/173

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
