### PR TITLE
feat: Allow disabling service creation to support creating just a task definition

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.88.0
+    rev: v1.88.1
     hooks:
       - id: terraform_fmt
       - id: terraform_wrapper_module_for_each

--- a/examples/fargate/README.md
+++ b/examples/fargate/README.md
@@ -74,7 +74,11 @@ No inputs.
 | <a name="output_service_iam_role_unique_id"></a> [service\_iam\_role\_unique\_id](#output\_service\_iam\_role\_unique\_id) | Stable and unique string identifying the service IAM role |
 | <a name="output_service_id"></a> [service\_id](#output\_service\_id) | ARN that identifies the service |
 | <a name="output_service_name"></a> [service\_name](#output\_service\_name) | Name of the service |
+| <a name="output_service_security_group_arn"></a> [service\_security\_group\_arn](#output\_service\_security\_group\_arn) | Amazon Resource Name (ARN) of the security group |
+| <a name="output_service_security_group_id"></a> [service\_security\_group\_id](#output\_service\_security\_group\_id) | ID of the security group |
 | <a name="output_service_task_definition_arn"></a> [service\_task\_definition\_arn](#output\_service\_task\_definition\_arn) | Full ARN of the Task Definition (including both `family` and `revision`) |
+| <a name="output_service_task_definition_family"></a> [service\_task\_definition\_family](#output\_service\_task\_definition\_family) | The unique name of the task definition |
+| <a name="output_service_task_definition_family_revision"></a> [service\_task\_definition\_family\_revision](#output\_service\_task\_definition\_family\_revision) | The family and revision (family:revision) of the task definition |
 | <a name="output_service_task_definition_revision"></a> [service\_task\_definition\_revision](#output\_service\_task\_definition\_revision) | Revision of the task in a particular family |
 | <a name="output_service_task_exec_iam_role_arn"></a> [service\_task\_exec\_iam\_role\_arn](#output\_service\_task\_exec\_iam\_role\_arn) | Task execution IAM role ARN |
 | <a name="output_service_task_exec_iam_role_name"></a> [service\_task\_exec\_iam\_role\_name](#output\_service\_task\_exec\_iam\_role\_name) | Task execution IAM role name |
@@ -86,6 +90,7 @@ No inputs.
 | <a name="output_service_tasks_iam_role_arn"></a> [service\_tasks\_iam\_role\_arn](#output\_service\_tasks\_iam\_role\_arn) | Tasks IAM role ARN |
 | <a name="output_service_tasks_iam_role_name"></a> [service\_tasks\_iam\_role\_name](#output\_service\_tasks\_iam\_role\_name) | Tasks IAM role name |
 | <a name="output_service_tasks_iam_role_unique_id"></a> [service\_tasks\_iam\_role\_unique\_id](#output\_service\_tasks\_iam\_role\_unique\_id) | Stable and unique string identifying the tasks IAM role |
+| <a name="output_task_definition_run_task_command"></a> [task\_definition\_run\_task\_command](#output\_task\_definition\_run\_task\_command) | awscli command to run the standalone task |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## License

--- a/examples/fargate/README.md
+++ b/examples/fargate/README.md
@@ -42,6 +42,7 @@ Note that this example may create resources which will incur monetary charges on
 | <a name="module_alb"></a> [alb](#module\_alb) | terraform-aws-modules/alb/aws | ~> 9.0 |
 | <a name="module_ecs_cluster"></a> [ecs\_cluster](#module\_ecs\_cluster) | ../../modules/cluster | n/a |
 | <a name="module_ecs_service"></a> [ecs\_service](#module\_ecs\_service) | ../../modules/service | n/a |
+| <a name="module_ecs_task_definition"></a> [ecs\_task\_definition](#module\_ecs\_task\_definition) | ../../modules/service | n/a |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 5.0 |
 
 ## Resources

--- a/examples/fargate/outputs.tf
+++ b/examples/fargate/outputs.tf
@@ -71,6 +71,16 @@ output "service_task_definition_revision" {
   value       = module.ecs_service.task_definition_revision
 }
 
+output "service_task_definition_family" {
+  description = "The unique name of the task definition"
+  value       = module.ecs_service.task_definition_family
+}
+
+output "service_task_definition_family_revision" {
+  description = "The family and revision (family:revision) of the task definition"
+  value       = module.ecs_service.task_definition_family_revision
+}
+
 output "service_task_exec_iam_role_name" {
   description = "Task execution IAM role name"
   value       = module.ecs_service.task_exec_iam_role_name
@@ -129,4 +139,28 @@ output "service_autoscaling_policies" {
 output "service_autoscaling_scheduled_actions" {
   description = "Map of autoscaling scheduled actions and their attributes"
   value       = module.ecs_service.autoscaling_scheduled_actions
+}
+
+output "service_security_group_arn" {
+  description = "Amazon Resource Name (ARN) of the security group"
+  value       = module.ecs_service.security_group_arn
+}
+
+output "service_security_group_id" {
+  description = "ID of the security group"
+  value       = module.ecs_service.security_group_id
+}
+
+################################################################################
+# Standalone Task Definition (w/o Service)
+################################################################################
+
+output "task_definition_run_task_command" {
+  description = "awscli command to run the standalone task"
+  value       = <<EOT
+    aws ecs run-task --cluster ${module.ecs_cluster.name} \
+      --task-definition ${module.ecs_task_definition.task_definition_family_revision} \
+      --network-configuration "awsvpcConfiguration={subnets=[${join(",", module.vpc.private_subnets)}],securityGroups=[${module.ecs_task_definition.security_group_id}]}" \
+      --region ${local.region}
+  EOT
 }

--- a/main.tf
+++ b/main.tf
@@ -53,7 +53,8 @@ module "service" {
 
   for_each = { for k, v in var.services : k => v if var.create }
 
-  create = try(each.value.create, true)
+  create         = try(each.value.create, true)
+  create_service = try(each.value.create_service, true)
 
   # Service
   ignore_task_definition_changes     = try(each.value.ignore_task_definition_changes, false)

--- a/modules/container-definition/main.tf
+++ b/modules/container-definition/main.tf
@@ -60,7 +60,7 @@ locals {
     secrets                = length(var.secrets) > 0 ? var.secrets : null
     startTimeout           = var.start_timeout
     stopTimeout            = var.stop_timeout
-    systemControls         = length(var.system_controls) > 0 ? var.system_controls : null
+    systemControls         = length(var.system_controls) > 0 ? var.system_controls : []
     ulimits                = local.is_not_windows && length(var.ulimits) > 0 ? var.ulimits : null
     user                   = local.is_not_windows ? var.user : null
     volumesFrom            = var.volumes_from

--- a/modules/service/README.md
+++ b/modules/service/README.md
@@ -338,6 +338,7 @@ module "ecs_service" {
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | ID of the security group |
 | <a name="output_task_definition_arn"></a> [task\_definition\_arn](#output\_task\_definition\_arn) | Full ARN of the Task Definition (including both `family` and `revision`) |
 | <a name="output_task_definition_family"></a> [task\_definition\_family](#output\_task\_definition\_family) | The unique name of the task definition |
+| <a name="output_task_definition_family_revision"></a> [task\_definition\_family\_revision](#output\_task\_definition\_family\_revision) | The family and revision (family:revision) of the task definition |
 | <a name="output_task_definition_revision"></a> [task\_definition\_revision](#output\_task\_definition\_revision) | Revision of the task in a particular family |
 | <a name="output_task_exec_iam_role_arn"></a> [task\_exec\_iam\_role\_arn](#output\_task\_exec\_iam\_role\_arn) | Task execution IAM role ARN |
 | <a name="output_task_exec_iam_role_name"></a> [task\_exec\_iam\_role\_name](#output\_task\_exec\_iam\_role\_name) | Task execution IAM role name |

--- a/modules/service/README.md
+++ b/modules/service/README.md
@@ -235,6 +235,7 @@ module "ecs_service" {
 | <a name="input_create"></a> [create](#input\_create) | Determines whether resources will be created (affects all resources) | `bool` | `true` | no |
 | <a name="input_create_iam_role"></a> [create\_iam\_role](#input\_create\_iam\_role) | Determines whether the ECS service IAM role should be created | `bool` | `true` | no |
 | <a name="input_create_security_group"></a> [create\_security\_group](#input\_create\_security\_group) | Determines if a security group is created | `bool` | `true` | no |
+| <a name="input_create_service"></a> [create\_service](#input\_create\_service) | Determines whether service resource will be created (set to `false` in case you want to create task definition only) | `bool` | `true` | no |
 | <a name="input_create_task_definition"></a> [create\_task\_definition](#input\_create\_task\_definition) | Determines whether to create a task definition or use existing/provided | `bool` | `true` | no |
 | <a name="input_create_task_exec_iam_role"></a> [create\_task\_exec\_iam\_role](#input\_create\_task\_exec\_iam\_role) | Determines whether the ECS task definition IAM role should be created | `bool` | `true` | no |
 | <a name="input_create_task_exec_policy"></a> [create\_task\_exec\_policy](#input\_create\_task\_exec\_policy) | Determines whether the ECS task definition IAM policy should be created. This includes permissions included in AmazonECSTaskExecutionRolePolicy as well as access to secrets and SSM parameters | `bool` | `true` | no |

--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -27,7 +27,7 @@ locals {
 }
 
 resource "aws_ecs_service" "this" {
-  count = var.create && !var.ignore_task_definition_changes ? 1 : 0
+  count = var.create && var.create_service && !var.ignore_task_definition_changes ? 1 : 0
 
   dynamic "alarms" {
     for_each = length(var.alarms) > 0 ? [var.alarms] : []
@@ -213,7 +213,7 @@ resource "aws_ecs_service" "this" {
 ################################################################################
 
 resource "aws_ecs_service" "ignore_task_definition" {
-  count = var.create && var.ignore_task_definition_changes ? 1 : 0
+  count = var.create && var.create_service && var.ignore_task_definition_changes ? 1 : 0
 
   dynamic "alarms" {
     for_each = length(var.alarms) > 0 ? [var.alarms] : []

--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -24,10 +24,12 @@ locals {
     security_groups  = flatten(concat([try(aws_security_group.this[0].id, [])], var.security_group_ids))
     subnets          = var.subnet_ids
   }
+
+  create_service = var.create && var.create_service
 }
 
 resource "aws_ecs_service" "this" {
-  count = var.create && var.create_service && !var.ignore_task_definition_changes ? 1 : 0
+  count = local.create_service && !var.ignore_task_definition_changes ? 1 : 0
 
   dynamic "alarms" {
     for_each = length(var.alarms) > 0 ? [var.alarms] : []
@@ -213,7 +215,7 @@ resource "aws_ecs_service" "this" {
 ################################################################################
 
 resource "aws_ecs_service" "ignore_task_definition" {
-  count = var.create && var.create_service && var.ignore_task_definition_changes ? 1 : 0
+  count = local.create_service && var.ignore_task_definition_changes ? 1 : 0
 
   dynamic "alarms" {
     for_each = length(var.alarms) > 0 ? [var.alarms] : []
@@ -1188,7 +1190,7 @@ resource "aws_ecs_task_set" "ignore_task_definition" {
 ################################################################################
 
 locals {
-  enable_autoscaling = var.create && var.enable_autoscaling && !local.is_daemon
+  enable_autoscaling = local.create_service && var.enable_autoscaling && !local.is_daemon
 
   cluster_name = element(split("/", var.cluster_arn), 1)
 }

--- a/modules/service/outputs.tf
+++ b/modules/service/outputs.tf
@@ -59,6 +59,11 @@ output "task_definition_family" {
   value       = try(aws_ecs_task_definition.this[0].family, null)
 }
 
+output "task_definition_family_revision" {
+  description = "The family and revision (family:revision) of the task definition"
+  value       = "${try(aws_ecs_task_definition.this[0].family, "")}:${local.max_task_def_revision}"
+}
+
 ################################################################################
 # Task Execution - IAM Role
 # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_execution_IAM_role.html

--- a/modules/service/variables.tf
+++ b/modules/service/variables.tf
@@ -4,6 +4,12 @@ variable "create" {
   default     = true
 }
 
+variable "create_service" {
+  description = "Determines whether service resource will be created (set to `false` in case you want to create task definition only)"
+  type        = bool
+  default     = true
+}
+
 variable "tags" {
   description = "A map of tags to add to all resources"
   type        = map(string)

--- a/wrappers/service/main.tf
+++ b/wrappers/service/main.tf
@@ -36,6 +36,7 @@ module "wrapper" {
   create                             = try(each.value.create, var.defaults.create, true)
   create_iam_role                    = try(each.value.create_iam_role, var.defaults.create_iam_role, true)
   create_security_group              = try(each.value.create_security_group, var.defaults.create_security_group, true)
+  create_service                     = try(each.value.create_service, var.defaults.create_service, true)
   create_task_definition             = try(each.value.create_task_definition, var.defaults.create_task_definition, true)
   create_task_exec_iam_role          = try(each.value.create_task_exec_iam_role, var.defaults.create_task_exec_iam_role, true)
   create_task_exec_policy            = try(each.value.create_task_exec_policy, var.defaults.create_task_exec_policy, true)


### PR DESCRIPTION
## Description
The new `create_service_resource` variable controls whether a `service` resource should be created (which is `true` by default) allowing skipping creation of the service when it's not required.

## Motivation and Context
- Resolves #162

## Breaking Changes
No breaking changes were introduced in the PR.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
