### PR TITLE
chore: add aws to required providers

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,9 @@
 terraform {
   required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+    }
+  }
 }


### PR DESCRIPTION
## Description
Add AWS provider to required_providers, omitting the version since that's inherited from child modules

## Motivation and Context
https://github.com/terraform-aws-modules/terraform-aws-ecs/issues/180

## Breaking Changes
No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
