### PR TITLE
fix: Don't default containers to run as root

### DIFF
--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -566,7 +566,7 @@ module "container_definition" {
   stop_timeout             = try(each.value.stop_timeout, var.container_definition_defaults.stop_timeout, 120)
   system_controls          = try(each.value.system_controls, var.container_definition_defaults.system_controls, [])
   ulimits                  = try(each.value.ulimits, var.container_definition_defaults.ulimits, [])
-  user                     = try(each.value.user, var.container_definition_defaults.user, 0)
+  user                     = try(each.value.user, var.container_definition_defaults.user, null)
   volumes_from             = try(each.value.volumes_from, var.container_definition_defaults.volumes_from, [])
   working_directory        = try(each.value.working_directory, var.container_definition_defaults.working_directory, null)
 


### PR DESCRIPTION
## Description
Changed the default `user` value for container definitions to not run as `root` by default.

## Motivation and Context
This value overrides the `USER` instruction defined in Dockerfile, this causes issues if images has this instruction set and it will override it to run as root.

## Breaking Changes
If developers expects the default user to be set to `root`, they will need to explicitly define this with
```hcl
    container_definitions = {
      key = {
        [...]
        user = 0 | "root"
      }
    }
```

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
