### PR TITLE
feat: Add Fargate example without Internet access

### DIFF
--- a/examples/fargate-private-ecr/README.md
+++ b/examples/fargate-private-ecr/README.md
@@ -1,0 +1,84 @@
+# ECS Clusters w/ Fargate and private network access
+
+The configuration in this directory creates:
+
+- an ECS cluster using Fargate (on-demand and spot) capacity providers
+- an example ECS standalone task that utilizes:
+  - VPC endpoints with a tight policy for the S3 Gateway endpoint
+  - a private ECR repository to pull container images from
+  - an S3 bucket to display its contents
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+The example output provides the commands to:
+- pull the container image for the AWS CLI from the Amazon ECR Public Gallery and push it to a private ECR repository from where the ECS task executor will be able to pull it
+- upload a test file to the S3 bucket whose contents the ECS task tries to list
+- run the standalone task manually
+
+Note that this example may create resources which will incur monetary charges on your AWS bill. Run `terraform destroy` when you no longer need these resources.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.66.1 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.66.1 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_ecr"></a> [ecr](#module\_ecr) | terraform-aws-modules/ecr/aws | ~> 2.2 |
+| <a name="module_ecs_cluster"></a> [ecs\_cluster](#module\_ecs\_cluster) | ../../modules/cluster | n/a |
+| <a name="module_ecs_task_definition"></a> [ecs\_task\_definition](#module\_ecs\_task\_definition) | ../../modules/service | n/a |
+| <a name="module_kms_bucket"></a> [kms\_bucket](#module\_kms\_bucket) | terraform-aws-modules/kms/aws | ~> 2.2 |
+| <a name="module_kms_cloudwatch"></a> [kms\_cloudwatch](#module\_kms\_cloudwatch) | terraform-aws-modules/kms/aws | ~> 2.2 |
+| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 4.1 |
+| <a name="module_security_group_vpc_endpoint_interface"></a> [security\_group\_vpc\_endpoint\_interface](#module\_security\_group\_vpc\_endpoint\_interface) | terraform-aws-modules/security-group/aws | ~> 5.1 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 5.0 |
+| <a name="module_vpc_endpoints"></a> [vpc\_endpoints](#module\_vpc\_endpoints) | terraform-aws-modules/vpc/aws//modules/vpc-endpoints | ~> 5.7 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.s3_endpoint](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_cluster_arn"></a> [cluster\_arn](#output\_cluster\_arn) | ARN that identifies the cluster |
+| <a name="output_cluster_autoscaling_capacity_providers"></a> [cluster\_autoscaling\_capacity\_providers](#output\_cluster\_autoscaling\_capacity\_providers) | Map of capacity providers created and their attributes |
+| <a name="output_cluster_capacity_providers"></a> [cluster\_capacity\_providers](#output\_cluster\_capacity\_providers) | Map of cluster capacity providers attributes |
+| <a name="output_cluster_id"></a> [cluster\_id](#output\_cluster\_id) | ID that identifies the cluster |
+| <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | Name that identifies the cluster |
+| <a name="output_private_ecr_repository_push_commands"></a> [private\_ecr\_repository\_push\_commands](#output\_private\_ecr\_repository\_push\_commands) | Commands to push the awscli container image to the private ECR repository |
+| <a name="output_task_definition_run_task_command"></a> [task\_definition\_run\_task\_command](#output\_task\_definition\_run\_task\_command) | awscli command to run the standalone task |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+## License
+
+Apache-2.0 Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-aws-ecs/blob/master/LICENSE).

--- a/examples/fargate-private-ecr/main.tf
+++ b/examples/fargate-private-ecr/main.tf
@@ -1,0 +1,390 @@
+provider "aws" {
+  region = local.region
+}
+
+data "aws_availability_zones" "available" {}
+
+data "aws_caller_identity" "current" {}
+
+locals {
+  region = "eu-west-2"
+  name   = "ex-${basename(path.cwd)}"
+
+  vpc_cidr = "10.0.0.0/16"
+  azs      = slice(data.aws_availability_zones.available.names, 0, 3)
+
+  tags = {
+    Name       = local.name
+    Example    = local.name
+    Repository = "https://github.com/terraform-aws-modules/terraform-aws-ecs"
+  }
+}
+
+################################################################################
+# Cluster
+################################################################################
+
+module "ecs_cluster" {
+  source = "../../modules/cluster"
+
+  cluster_name = local.name
+
+  # Capacity provider
+  fargate_capacity_providers = {
+    FARGATE = {
+      default_capacity_provider_strategy = {
+        weight = 50
+        base   = 20
+      }
+    }
+    FARGATE_SPOT = {
+      default_capacity_provider_strategy = {
+        weight = 50
+      }
+    }
+  }
+
+  cloudwatch_log_group_kms_key_id = module.kms_cloudwatch.key_arn
+
+  tags = local.tags
+}
+
+################################################################################
+# Standalone Task Definition (w/o Service)
+################################################################################
+
+module "ecs_task_definition" {
+  source = "../../modules/service"
+
+  # Service
+  name        = "${local.name}-standalone"
+  cluster_arn = module.ecs_cluster.arn
+
+  # Task Definition
+  volume = {
+    ex-vol = {}
+  }
+
+  runtime_platform = {
+    cpu_architecture        = "X86_64"
+    operating_system_family = "LINUX"
+  }
+
+  # Container definition(s)
+  container_definitions = {
+    al2023 = {
+      image = "${module.ecr.repository_url}:latest"
+
+      mount_points = [
+        {
+          sourceVolume  = "ex-vol",
+          containerPath = "/var/www/ex-vol"
+        }
+      ]
+
+      command    = ["aws --region ${local.region} s3 ls ${module.s3_bucket.s3_bucket_id}"]
+      entrypoint = ["/usr/bin/sh", "-c"]
+    }
+  }
+
+  subnet_ids = module.vpc.intra_subnets
+
+  security_group_rules = {
+    egress_all = {
+      type        = "egress"
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_blocks = ["0.0.0.0/0"]
+    }
+  }
+
+  propagate_tags = "TASK_DEFINITION"
+
+  tags = local.tags
+}
+
+################################################################################
+# Supporting Resources
+################################################################################
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 5.0"
+
+  name = local.name
+  cidr = local.vpc_cidr
+
+  azs = local.azs
+
+  # Intra subnets are designed to have no Internet access via NAT Gateway.
+  intra_subnets = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 4, k)]
+
+  tags = local.tags
+}
+
+module "vpc_endpoints" {
+  source  = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
+  version = "~> 5.7"
+
+  vpc_id = module.vpc.vpc_id
+
+  # Amazon ECS tasks hosted on Fargate using platform version 1.4.0 or later require both
+  # Amazon ECR VPC endpoints (ecr.dkr and ecr.api) and the Amazon S3 gateway endpoints.
+  endpoints = merge({
+    s3 = {
+      service         = "s3"
+      service_type    = "Gateway"
+      route_table_ids = module.vpc.intra_route_table_ids
+      policy          = data.aws_iam_policy_document.s3_endpoint.json
+      tags = {
+        "Name" = "${local.name}-s3"
+      }
+    }
+    },
+    {
+      for service in toset(["ecr.api", "ecr.dkr", "ecs", "ecs-telemetry", "ecs-agent", "logs"]) :
+      replace(service, ".", "_") =>
+      {
+        service             = service
+        private_dns_enabled = true
+        subnet_ids          = module.vpc.intra_subnets
+        security_group_ids  = [module.security_group_vpc_endpoint_interface.security_group_id]
+        tags = {
+          "Name" = "${local.name}-${service}"
+        }
+      }
+  })
+
+  tags = local.tags
+}
+
+data "aws_iam_policy_document" "s3_endpoint" {
+  # See https://docs.aws.amazon.com/AmazonECR/latest/userguide/vpc-endpoints.html#ecr-minimum-s3-perms
+  statement {
+    sid = "AllowBucketAccessForECROperations"
+
+    # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document#principals-and-not_principals
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    actions = [
+      "s3:GetObject",
+    ]
+
+    resources = [
+      "arn:aws:s3:::prod-${local.region}-starport-layer-bucket/*",
+    ]
+  }
+
+  # See https://docs.aws.amazon.com/vpc/latest/privatelink/vpc-endpoints-s3.html#edit-vpc-endpoint-policy-s3
+  statement {
+    sid = "RestrictBucketAccessToIAMRole"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    actions = [
+      "s3:PutObject",
+      "s3:GetObject",
+      "s3:ListBucket",
+    ]
+
+    resources = [
+      "${module.s3_bucket.s3_bucket_arn}/*",
+      module.s3_bucket.s3_bucket_arn,
+    ]
+
+    condition {
+      test     = "ArnEquals"
+      variable = "aws:PrincipalArn"
+      values   = [module.ecs_task_definition.tasks_iam_role_arn]
+    }
+  }
+}
+
+module "security_group_vpc_endpoint_interface" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "~> 5.1"
+
+  name        = local.name
+  description = "Security Group for VPC Endpoint Ingress"
+
+  vpc_id = module.vpc.vpc_id
+
+  ingress_cidr_blocks = module.vpc.intra_subnets_cidr_blocks
+
+  ingress_rules = ["https-443-tcp"]
+
+  tags = local.tags
+}
+
+module "kms_cloudwatch" {
+  source  = "terraform-aws-modules/kms/aws"
+  version = "~> 2.2"
+
+  description = "CloudWatch log encryption"
+
+  computed_aliases = {
+    logs = {
+      name = "${local.name}-cloudwatch"
+    }
+  }
+  aliases_use_name_prefix = true
+
+  # See: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html#cmk-permissions
+  key_statements = [
+    {
+      sid = "CloudWatchLogs"
+
+      actions = [
+        "kms:Encrypt*",
+        "kms:Decrypt*",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:Describe*"
+      ]
+
+      resources = [
+        "*"
+      ]
+
+      principals = [
+        {
+          type        = "Service"
+          identifiers = ["logs.${local.region}.amazonaws.com"]
+        }
+      ]
+
+      conditions = [
+        {
+          test     = "ArnLike"
+          variable = "kms:EncryptionContext:aws:logs:arn"
+          values = [
+            "arn:aws:logs:${local.region}:${data.aws_caller_identity.current.account_id}:log-group:*",
+          ]
+        }
+      ]
+    }
+  ]
+
+  tags = merge(
+    {
+      # This module doesn't create resource-specific "Name" tags as the "name" input variable is not present
+      "Name" = local.name
+    },
+    local.tags,
+  )
+}
+
+module "kms_bucket" {
+  source  = "terraform-aws-modules/kms/aws"
+  version = "~> 2.2"
+
+  description = "S3 encryption"
+
+  computed_aliases = {
+    s3 = {
+      name = "${local.name}-s3"
+    }
+  }
+  aliases_use_name_prefix = true
+
+  # Grants
+  grants = {
+    ecs = {
+      grantee_principal = module.ecs_task_definition.tasks_iam_role_arn
+      operations = [
+        "GenerateDataKey",
+        "Decrypt",
+        "Encrypt",
+      ]
+    }
+  }
+
+  tags = merge(
+    {
+      # This module doesn't create resource-specific "Name" tags as the "name" input variable is not present
+      "Name" = local.name
+    },
+    local.tags,
+  )
+}
+
+module "s3_bucket" {
+  source  = "terraform-aws-modules/s3-bucket/aws"
+  version = "~> 4.1"
+
+  bucket_prefix = "${local.name}-"
+  force_destroy = true
+
+  # S3 bucket-level Public Access Block configuration
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+
+  versioning = {
+    enabled = true
+  }
+
+  # Bucket policy
+  attach_policy = true
+  policy        = data.aws_iam_policy_document.bucket.json
+
+  server_side_encryption_configuration = {
+    rule = {
+      apply_server_side_encryption_by_default = {
+        kms_master_key_id = module.kms_bucket.key_id
+        sse_algorithm     = "aws:kms"
+      }
+    }
+  }
+
+  tags = merge(
+    {
+      # This module doesn't create resource-specific "Name" tags as the "name" input variable is not present
+      "Name" = local.name
+    },
+    local.tags,
+  )
+}
+
+data "aws_iam_policy_document" "bucket" {
+  statement {
+    sid = "RestrictBucketAccessToIAMRole"
+
+    principals {
+      type        = "AWS"
+      identifiers = [module.ecs_task_definition.tasks_iam_role_arn]
+    }
+
+    actions = [
+      "s3:PutObject",
+      "s3:GetObject",
+      "s3:ListBucket",
+    ]
+
+    resources = [
+      "${module.s3_bucket.s3_bucket_arn}/*",
+      module.s3_bucket.s3_bucket_arn,
+    ]
+  }
+}
+
+module "ecr" {
+  source  = "terraform-aws-modules/ecr/aws"
+  version = "~> 2.2"
+
+  repository_name = local.name
+
+  repository_force_delete     = true
+  create_lifecycle_policy     = false
+  repository_read_access_arns = [module.ecs_task_definition.task_exec_iam_role_arn]
+
+  tags = local.tags
+}

--- a/examples/fargate-private-ecr/outputs.tf
+++ b/examples/fargate-private-ecr/outputs.tf
@@ -1,0 +1,65 @@
+################################################################################
+# Cluster
+################################################################################
+
+output "cluster_arn" {
+  description = "ARN that identifies the cluster"
+  value       = module.ecs_cluster.arn
+}
+
+output "cluster_id" {
+  description = "ID that identifies the cluster"
+  value       = module.ecs_cluster.id
+}
+
+output "cluster_name" {
+  description = "Name that identifies the cluster"
+  value       = module.ecs_cluster.name
+}
+
+output "cluster_capacity_providers" {
+  description = "Map of cluster capacity providers attributes"
+  value       = module.ecs_cluster.cluster_capacity_providers
+}
+
+output "cluster_autoscaling_capacity_providers" {
+  description = "Map of capacity providers created and their attributes"
+  value       = module.ecs_cluster.autoscaling_capacity_providers
+}
+
+################################################################################
+# Private ECR Repository
+################################################################################
+output "private_ecr_repository_push_commands" {
+  description = "Commands to push the awscli container image to the private ECR repository"
+  value       = <<EOT
+    aws ecr get-login-password --region ${local.region} | docker login --username AWS --password-stdin ${data.aws_caller_identity.current.account_id}.dkr.ecr.${local.region}.amazonaws.com
+    docker pull public.ecr.aws/aws-cli/aws-cli:latest
+    docker tag public.ecr.aws/aws-cli/aws-cli:latest ${module.ecr.repository_url}:latest
+    docker push ${module.ecr.repository_url}:latest
+  EOT
+}
+
+################################################################################
+# S3 bucket
+################################################################################
+output "s3_bucket_upload_command" {
+  description = "Command to upload files to the example S3 bucket"
+  value       = <<EOT
+    aws s3 cp <file> s3://${module.s3_bucket.s3_bucket_id}
+  EOT
+}
+
+################################################################################
+# Standalone Task Definition (w/o Service)
+################################################################################
+
+output "task_definition_run_task_command" {
+  description = "awscli command to run the standalone task"
+  value       = <<EOT
+    aws ecs run-task --cluster ${module.ecs_cluster.name} \
+      --task-definition ${module.ecs_task_definition.task_definition_family_revision} \
+      --network-configuration "awsvpcConfiguration={subnets=[${join(",", module.vpc.intra_subnets)}],securityGroups=[${module.ecs_task_definition.security_group_id}]}" \
+      --region ${local.region}
+  EOT
+}

--- a/examples/fargate-private-ecr/versions.tf
+++ b/examples/fargate-private-ecr/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.66.1"
+    }
+  }
+}


### PR DESCRIPTION
## Description
Add a Fargate example for using a private ECR repository over VPC Endpoints with a tight policy for the S3 Gateway Endpoint. 

## Motivation and Context
I thought to provide the community with a working example where a tight policy is used for the S3 Gateway Endpoint, as per relevant [ECR documentation](https://docs.aws.amazon.com/AmazonECR/latest/userguide/vpc-endpoints.html#ecr-minimum-s3-perms). In particular, expose the following resource:
```
"arn:aws:s3:::prod-${local.region}-starport-layer-bucket/*",
```

## Breaking Changes
None

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
