### PR TITLE
feat: Use a list instead of a map when defining services in service connect configuration

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -108,10 +108,10 @@ module "ecs" {
       service_connect_configuration = {
         namespace = aws_service_discovery_http_namespace.this.arn
         service = [{
-          client_alias = {
+          client_alias = [{
             port     = local.container_port
             dns_name = local.container_name
-          }
+          }]
           port_name      = local.container_name
           discovery_name = local.container_name
         }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -107,7 +107,7 @@ module "ecs" {
 
       service_connect_configuration = {
         namespace = aws_service_discovery_http_namespace.this.arn
-        service = {
+        service = [{
           client_alias = {
             port     = local.container_port
             dns_name = local.container_name
@@ -115,7 +115,7 @@ module "ecs" {
           port_name      = local.container_name
           discovery_name = local.container_name
         }
-      }
+      }]
 
       load_balancer = {
         service = {

--- a/examples/fargate/main.tf
+++ b/examples/fargate/main.tf
@@ -133,14 +133,14 @@ module "ecs_service" {
 
   service_connect_configuration = {
     namespace = aws_service_discovery_http_namespace.this.arn
-    service = {
-      client_alias = {
+    service = [{
+      client_alias = [{
         port     = local.container_port
         dns_name = local.container_name
-      }
+      }]
       port_name      = local.container_name
       discovery_name = local.container_name
-    }
+    }]
   }
 
   load_balancer = {

--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -155,12 +155,12 @@ resource "aws_ecs_service" "this" {
       namespace = lookup(service_connect_configuration.value, "namespace", null)
 
       dynamic "service" {
-        for_each = try([service_connect_configuration.value.service], [])
+        for_each = try(service_connect_configuration.value.service, [])
 
         content {
 
           dynamic "client_alias" {
-            for_each = try([service.value.client_alias], [])
+            for_each = try(service.value.client_alias, [])
 
             content {
               dns_name = try(client_alias.value.dns_name, null)
@@ -341,12 +341,12 @@ resource "aws_ecs_service" "ignore_task_definition" {
       namespace = lookup(service_connect_configuration.value, "namespace", null)
 
       dynamic "service" {
-        for_each = try([service_connect_configuration.value.service], [])
+        for_each = try(service_connect_configuration.value.service, [])
 
         content {
 
           dynamic "client_alias" {
-            for_each = try([service.value.client_alias], [])
+            for_each = try(service.value.client_alias, [])
 
             content {
               dns_name = try(client_alias.value.dns_name, null)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
I modified the service connect configuration block in the service module to allow for multiple services configs in a parent service. This change aligns with how Service Connect is defined in the API.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is required to allow users to define multiple endpoints for multiple ports/containers in their task definitions. Currently, the module only supports one service connect config per service.
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
Yes
<!-- If so, please provide an explanation why it is necessary. -->
The change is necessary to align with the AWS API for defining services in the service connect config.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request

I've updated my locally downloaded version of the module with the same changes, and updated my HCL to look like so:
```

locals {
  container_definitions = {
    "a" = {
      port = 8080
    }

    "b" = {
       port = 9090
    }
  }

}


  service_connect_configuration = {
    namespace = aws_service_discovery_http_namespace.namespace.arn

    service = [
      for k, v in local.container_definitions :
      {
        discovery_name = "container_${k}"
        port_name = "container_${k}"
        client_alias = [
          {
            dns_name = "container_${k}"
            port = v.port
          }
        ]
      }
    ]
  }
```

and the plan is correct.

<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
