### PR TITLE
feat: Add support for custom metric queries in customized_metric_spec

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.86.0
+    rev: v1.90.0
     hooks:
       - id: terraform_fmt
       - id: terraform_wrapper_module_for_each
@@ -24,7 +24,7 @@ repos:
           - '--args=--only=terraform_workspace_remote'
       - id: terraform_validate
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer

--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -1243,6 +1243,37 @@ resource "aws_appautoscaling_policy" "this" {
         for_each = try([target_tracking_scaling_policy_configuration.value.customized_metric_specification], [])
 
         content {
+          dynamic "metrics"{
+            for_each = try(customized_metric_specification.value.metrics, [])
+            content {
+              id = metrics.value.id
+              label = try(metrics.value.label, null)
+              return_data = try(metrics.value.return_data, true)
+              expression = try(metrics.value.expression, null)
+
+
+              dynamic "metric_stat" {
+                for_each = try([metrics.value.metric_stat], [])
+                content {
+                  stat = metric_stat.value.stat
+                  dynamic "metric" {
+                    for_each = try([metric_stat.value.metric], [])
+                    content {
+                      namespace = metric.value.namespace
+                      metric_name = metric.value.metric_name
+                      dynamic "dimensions" {
+                        for_each = try(metric.value.dimensions, [])
+                        content {
+                          name = dimensions.value.name
+                          value = dimensions.value.value
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
           dynamic "dimensions" {
             for_each = try(customized_metric_specification.value.dimensions, [])
 
@@ -1252,9 +1283,9 @@ resource "aws_appautoscaling_policy" "this" {
             }
           }
 
-          metric_name = customized_metric_specification.value.metric_name
-          namespace   = customized_metric_specification.value.namespace
-          statistic   = customized_metric_specification.value.statistic
+          metric_name = try(customized_metric_specification.value.metric_name, null)
+          namespace   = try(customized_metric_specification.value.namespace, null)
+          statistic   = try(customized_metric_specification.value.statistic, null)
           unit        = try(customized_metric_specification.value.unit, null)
         }
       }

--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -1243,13 +1243,13 @@ resource "aws_appautoscaling_policy" "this" {
         for_each = try([target_tracking_scaling_policy_configuration.value.customized_metric_specification], [])
 
         content {
-          dynamic "metrics"{
+          dynamic "metrics" {
             for_each = try(customized_metric_specification.value.metrics, [])
             content {
-              id = metrics.value.id
-              label = try(metrics.value.label, null)
+              id          = metrics.value.id
+              label       = try(metrics.value.label, null)
               return_data = try(metrics.value.return_data, true)
-              expression = try(metrics.value.expression, null)
+              expression  = try(metrics.value.expression, null)
 
 
               dynamic "metric_stat" {
@@ -1259,12 +1259,12 @@ resource "aws_appautoscaling_policy" "this" {
                   dynamic "metric" {
                     for_each = try([metric_stat.value.metric], [])
                     content {
-                      namespace = metric.value.namespace
+                      namespace   = metric.value.namespace
                       metric_name = metric.value.metric_name
                       dynamic "dimensions" {
                         for_each = try(metric.value.dimensions, [])
                         content {
-                          name = dimensions.value.name
+                          name  = dimensions.value.name
                           value = dimensions.value.value
                         }
                       }

--- a/wrappers/cluster/versions.tf
+++ b/wrappers/cluster/versions.tf
@@ -1,3 +1,10 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.3"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.34"
+    }
+  }
 }

--- a/wrappers/container-definition/versions.tf
+++ b/wrappers/container-definition/versions.tf
@@ -1,3 +1,10 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.3"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.34"
+    }
+  }
 }

--- a/wrappers/service/versions.tf
+++ b/wrappers/service/versions.tf
@@ -1,3 +1,10 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.3"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.34"
+    }
+  }
 }

--- a/wrappers/versions.tf
+++ b/wrappers/versions.tf
@@ -1,3 +1,10 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.3"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.34"
+    }
+  }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
I added support for customized_metric_specification when using the `metrics` block, instead of using the current setup: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_policy.html#create-target-tracking-scaling-policy-using-metric-math

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change adds support for metric math in queries, which is useful for things like SQS-queue size based autoscaling
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
No, since you can still specify a metric the old way
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->

There was no example to test against, but the example code would look like so:
```
  autoscaling_policies = {
    "scale_consumer" = {
        policy_type = "TargetTrackingScaling"
        target_tracking_scaling_policy_configuration = {
          customized_metric_specification = {
            metrics = [{
                id = "m1"
                label = "Get the queue size"
                return_data = false
                metric_stat = {
                  metric = {
                    metric_name = "ApproximateNumberOfMessagesVisible"
                    namespace = "AWS/SQS"
                    dimensions = [{
                      name = "QueueName"
                      value = aws_sqs_queue.queue.name
                    }]
                  }
                  stat = "Sum"
                }
            },
            {
              id = "m2"
              label = "Get the number of running tasks"
              return_data = false
              metric_stat = {
                metric = {
                  metric_name = "RunningTaskCount"
                  namespace = "ECS/ContainerInsights"
                  dimensions = [
                    {
                      name = "ClusterName"
                      value = module.ecs_cluster.name
                    },
                    {
                      name = "ServiceName"
                      value = "queue-processing-service"
                    }
                  ]
                }
                stat = "Average"
              }
            },
            {
              id = "e1"
              label = "Calculate the backlog per group of instances"
              expression = "m1 / m2"
              return_data = true
            }]
          }
          target_value = 1000
      }
    }
  }
```

- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
