### PR TITLE
Remove dict comprehension

### DIFF
--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -524,7 +524,7 @@ resource "aws_iam_role_policy_attachment" "service" {
 module "container_definition" {
   source = "../container-definition"
 
-  for_each = { for k, v in var.container_definitions : k => v if local.create_task_definition && try(v.create, true) }
+  for_each = local.create_task_definition ? var.container_definitions : {}
 
   operating_system_family = try(var.runtime_platform.operating_system_family, "LINUX")
 


### PR DESCRIPTION
Dict comprehension was causing the for_each to error if any setting, either key or value was dynamic, disallowing use from setting envvars created via other terraform resources.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
