### PR TITLE
fix: Make service, task, and task sets wait for their respective policy attachment to ensure permissions are available

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.88.4
+    rev: v1.90.0
     hooks:
       - id: terraform_fmt
       - id: terraform_wrapper_module_for_each

--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -201,7 +201,9 @@ resource "aws_ecs_service" "this" {
     delete = try(var.timeouts.delete, null)
   }
 
-  depends_on = [aws_iam_role_policy_attachment.service]
+  depends_on = [
+    aws_iam_role_policy_attachment.service
+  ]
 
   lifecycle {
     ignore_changes = [
@@ -387,7 +389,9 @@ resource "aws_ecs_service" "ignore_task_definition" {
     delete = try(var.timeouts.delete, null)
   }
 
-  depends_on = [aws_iam_role_policy_attachment.service]
+  depends_on = [
+    aws_iam_role_policy_attachment.service
+  ]
 
   lifecycle {
     ignore_changes = [
@@ -735,6 +739,12 @@ resource "aws_ecs_task_definition" "this" {
   }
 
   tags = merge(var.tags, var.task_tags)
+
+  depends_on = [
+    aws_iam_role_policy_attachment.tasks,
+    aws_iam_role_policy_attachment.task_exec,
+    aws_iam_role_policy_attachment.task_exec_additional,
+  ]
 
   lifecycle {
     create_before_destroy = true

--- a/wrappers/cluster/versions.tf
+++ b/wrappers/cluster/versions.tf
@@ -1,3 +1,10 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.66.1"
+    }
+  }
 }

--- a/wrappers/container-definition/versions.tf
+++ b/wrappers/container-definition/versions.tf
@@ -1,3 +1,10 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.66.1"
+    }
+  }
 }

--- a/wrappers/service/versions.tf
+++ b/wrappers/service/versions.tf
@@ -1,3 +1,10 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.66.1"
+    }
+  }
 }

--- a/wrappers/versions.tf
+++ b/wrappers/versions.tf
@@ -1,3 +1,10 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.66.1"
+    }
+  }
 }


### PR DESCRIPTION
## Description
- Make service, task, and task sets wait for their respective policy attachment to ensure permissions are available

## Motivation and Context
- Resolves #200

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
