### PR TITLE
fix: Add missing `pid_mode` to root module

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.90.0
+    rev: v1.92.0
     hooks:
       - id: terraform_fmt
       - id: terraform_wrapper_module_for_each

--- a/main.tf
+++ b/main.tf
@@ -108,9 +108,9 @@ module "service" {
   family                        = try(each.value.family, null)
   inference_accelerator         = try(each.value.inference_accelerator, {})
   ipc_mode                      = try(each.value.ipc_mode, null)
-  pid_mode                      = try(each.value.pid_mode, null)
   memory                        = try(each.value.memory, 2048)
   network_mode                  = try(each.value.network_mode, "awsvpc")
+  pid_mode                      = try(each.value.pid_mode, null)
   proxy_configuration           = try(each.value.proxy_configuration, {})
   requires_compatibilities      = try(each.value.requires_compatibilities, ["FARGATE"])
   runtime_platform = try(each.value.runtime_platform, {

--- a/main.tf
+++ b/main.tf
@@ -108,6 +108,7 @@ module "service" {
   family                        = try(each.value.family, null)
   inference_accelerator         = try(each.value.inference_accelerator, {})
   ipc_mode                      = try(each.value.ipc_mode, null)
+  pid_mode                      = try(each.value.pid_mode, null)
   memory                        = try(each.value.memory, 2048)
   network_mode                  = try(each.value.network_mode, "awsvpc")
   proxy_configuration           = try(each.value.proxy_configuration, {})


### PR DESCRIPTION
Missing pid_mod.

## Description
<!--- Describe your changes in detail -->
Missing  pid_mode in main.tf.  


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Was not able to set:
pid_mode                 = "task"

<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No
## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
