### PR TITLE
feat: Add support for service connect timeouts

### DIFF
--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -168,9 +168,17 @@ resource "aws_ecs_service" "this" {
             }
           }
 
+          dynamic "timeout" {
+            for_each = try([service.value.timeout], [])
+
+            content {
+              idle_timeout_seconds = try(timeout.value.idle_timeout_seconds, null)
+              per_request_timeout_seconds = try(timeout.value.per_request_timeout_seconds, null)
+            }
+          }
+
           discovery_name        = try(service.value.discovery_name, null)
           ingress_port_override = try(service.value.ingress_port_override, null)
-          timeout               = try(service.value.timeout, null) 
           port_name             = service.value.port_name
         }
       }

--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -170,11 +170,8 @@ resource "aws_ecs_service" "this" {
 
           discovery_name        = try(service.value.discovery_name, null)
           ingress_port_override = try(service.value.ingress_port_override, null)
+          timeout               = try(service.value.timeout, null) 
           port_name             = service.value.port_name
-          timeout {
-            idle_timeout_seconds = 20
-            per_request_timeout_seconds = 20
-          }
         }
       }
     }

--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -171,6 +171,10 @@ resource "aws_ecs_service" "this" {
           discovery_name        = try(service.value.discovery_name, null)
           ingress_port_override = try(service.value.ingress_port_override, null)
           port_name             = service.value.port_name
+          timeout {
+            idle_timeout_seconds = 20
+            per_request_timeout_seconds = 20
+          }
         }
       }
     }


### PR DESCRIPTION
This pull request will add support for a timeout block in the service block of service_connect_configuration. Default idle_timeout_seconds = 300, per_request_timeout_seconds = 15 as defined by AWS. These values are too low for longrunning requests so they had to be configurable.
