### PR TITLE
feat: Add support for service connect tls settings

### DIFF
--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -190,7 +190,7 @@ resource "aws_ecs_service" "this" {
                 }
               }
 
-              kms_key = try(tls.value.kms_key, null)
+              kms_key  = try(tls.value.kms_key, null)
               role_arn = try(tls.value.role_arn, null)
             }
           }
@@ -426,7 +426,7 @@ resource "aws_ecs_service" "ignore_task_definition" {
                 for_each = tls.value.issuer_cert_authority
 
                 content {
-                  aws_pca_authority_arn = try(issuer_cert_authority.value.aws_pca_authority_arn, null)
+                  aws_pca_authority_arn = issuer_cert_authority.value.aws_pca_authority_arn
                 }
               }
 

--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -186,7 +186,7 @@ resource "aws_ecs_service" "this" {
                 for_each = tls.value.issuer_cert_authority
 
                 content {
-                  aws_pca_authority_arn = try(issuer_cert_authority.value.aws_pca_authority_arn, null)
+                  aws_pca_authority_arn = issuer_cert_authority.value.aws_pca_authority_arn
                 }
               }
 

--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -177,6 +177,24 @@ resource "aws_ecs_service" "this" {
             }
           }
 
+          dynamic "tls" {
+            for_each = try([service.value.tls], [])
+
+            content {
+
+              dynamic "issuer_cert_authority" {
+                for_each = tls.value.issuer_cert_authority
+
+                content {
+                  aws_pca_authority_arn = try(issuer_cert_authority.value.aws_pca_authority_arn, null)
+                }
+              }
+
+              kms_key = try(tls.value.kms_key, null)
+              role_arn = try(tls.value.role_arn, null)
+            }
+          }
+
           discovery_name        = try(service.value.discovery_name, null)
           ingress_port_override = try(service.value.ingress_port_override, null)
           port_name             = service.value.port_name
@@ -396,6 +414,24 @@ resource "aws_ecs_service" "ignore_task_definition" {
             content {
               idle_timeout_seconds        = try(timeout.value.idle_timeout_seconds, null)
               per_request_timeout_seconds = try(timeout.value.per_request_timeout_seconds, null)
+            }
+          }
+
+          dynamic "tls" {
+            for_each = try([service.value.tls], [])
+
+            content {
+
+              dynamic "issuer_cert_authority" {
+                for_each = tls.value.issuer_cert_authority
+
+                content {
+                  aws_pca_authority_arn = try(issuer_cert_authority.value.aws_pca_authority_arn, null)
+                }
+              }
+
+              kms_key = try(tls.value.kms_key, null)
+              role_arn = try(tls.value.role_arn, null)
             }
           }
 

--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -430,7 +430,7 @@ resource "aws_ecs_service" "ignore_task_definition" {
                 }
               }
 
-              kms_key = try(tls.value.kms_key, null)
+              kms_key  = try(tls.value.kms_key, null)
               role_arn = try(tls.value.role_arn, null)
             }
           }


### PR DESCRIPTION
## Description
Adds support for `tls` under `service_connect_configuration.service`. Within `tls`, you can specify `issuer_cert_authority`, `kms_key` and `role_arn`. Those fields are documented [here](https://registry.terraform.io/providers/-/aws/5.45.0/docs/resources/ecs_service#tls).

## Motivation and Context
This change allows the user to enable TLS and encrypt Service Connect traffic. The default settings are not adequate for all use cases.

## Breaking Changes
None

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

No examples were appended due to the nature of the TLS configuration requiring an AWS Certificate Manager Private Certificate Authority. If you feel this should be implemented in one of the examples anyway, let me know.