### PR TITLE
fix: Local `cluster_name` error when `var.cluster_arn` is empty

### DIFF
--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -1203,7 +1203,7 @@ resource "aws_ecs_task_set" "ignore_task_definition" {
 locals {
   enable_autoscaling = local.create_service && var.enable_autoscaling && !local.is_daemon
 
-  cluster_name = element(split("/", var.cluster_arn), 1)
+  cluster_name = try(element(split("/", var.cluster_arn), 1), "")
 }
 
 resource "aws_appautoscaling_target" "this" {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

When configuring `modules/service` to disable service creation with parameters:
```
  create         = false
  create_service = false
```
The following error happens

```
Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: Invalid function argument
│ 
│   on .terraform/modules/service/main.tf line 1206, in locals:
│ 1206:   cluster_name = element(split("/", var.cluster_arn), 1)
│     ├────────────────
│     │ while calling split(separator, str)
│     │ var.cluster_arn is null
│ 
│ Invalid value for "str" parameter: argument must not be null.
╵
```

This change make it works in with create true/false without error.
## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
