### PR TITLE
fix: Use IAM path for creating the policy as well [WIP]

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ No resources.
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 | <a name="input_task_exec_iam_role_description"></a> [task\_exec\_iam\_role\_description](#input\_task\_exec\_iam\_role\_description) | Description of the role | `string` | `null` | no |
 | <a name="input_task_exec_iam_role_name"></a> [task\_exec\_iam\_role\_name](#input\_task\_exec\_iam\_role\_name) | Name to use on IAM role created | `string` | `null` | no |
-| <a name="input_task_exec_iam_role_path"></a> [task\_exec\_iam\_role\_path](#input\_task\_exec\_iam\_role\_path) | IAM role path | `string` | `null` | no |
+| <a name="input_task_exec_iam_role_path"></a> [task\_exec\_iam\_role\_path](#input\_task\_exec\_iam\_role\_path) | IAM role path used for creating the role and the IAM policy | `string` | `null` | no |
 | <a name="input_task_exec_iam_role_permissions_boundary"></a> [task\_exec\_iam\_role\_permissions\_boundary](#input\_task\_exec\_iam\_role\_permissions\_boundary) | ARN of the policy that is used to set the permissions boundary for the IAM role | `string` | `null` | no |
 | <a name="input_task_exec_iam_role_policies"></a> [task\_exec\_iam\_role\_policies](#input\_task\_exec\_iam\_role\_policies) | Map of IAM role policy ARNs to attach to the IAM role | `map(string)` | `{}` | no |
 | <a name="input_task_exec_iam_role_tags"></a> [task\_exec\_iam\_role\_tags](#input\_task\_exec\_iam\_role\_tags) | A map of additional tags to add to the IAM role created | `map(string)` | `{}` | no |

--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -510,6 +510,7 @@ resource "aws_iam_policy" "service" {
   name_prefix = var.iam_role_use_name_prefix ? "${local.iam_role_name}-" : null
   description = coalesce(var.iam_role_description, "ECS service policy that allows Amazon ECS to make calls to your load balancer on your behalf")
   policy      = data.aws_iam_policy_document.service[0].json
+  path        = var.iam_role_path
 
   tags = merge(var.tags, var.iam_role_tags)
 }
@@ -894,6 +895,7 @@ resource "aws_iam_policy" "task_exec" {
   name_prefix = var.task_exec_iam_role_use_name_prefix ? "${local.task_exec_iam_role_name}-" : null
   description = coalesce(var.task_exec_iam_role_description, "Task execution role IAM policy")
   policy      = data.aws_iam_policy_document.task_exec[0].json
+  path        = var.task_exec_iam_role_path
 
   tags = merge(var.tags, var.task_exec_iam_role_tags)
 }


### PR DESCRIPTION
## Description
The IAM policies created for the task execution role are not created in any `path`s provided in the module inputs. 


## Motivation and Context
Control over the `path` where the IAM policies are created in; for more granular control and organization.


## Breaking Changes
No breaking changes

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
