### PR TITLE
fix: Correct logic for local `needs_infrastructure_iam_role` check

### DIFF
--- a/examples/ec2-autoscaling/main.tf
+++ b/examples/ec2-autoscaling/main.tf
@@ -95,7 +95,6 @@ module "ecs_service" {
     }
   }
 
-  create_infrastructure_iam_role = true
   volume_configuration = {
     ebs-volume = {
       managed_ebs_volume = {

--- a/main.tf
+++ b/main.tf
@@ -100,7 +100,7 @@ module "service" {
   iam_role_statements           = lookup(each.value, "iam_role_statements", {})
 
   # ECS infrastructure IAM role
-  create_infrastructure_iam_role = try(each.value.create_infrastructure_iam_role, false)
+  create_infrastructure_iam_role = try(each.value.create_infrastructure_iam_role, true)
   infrastructure_iam_role_arn = try(each.value.infrastructure_iam_role_arn, null)
   infrastructure_iam_role_name = try(each.value.infrastructure_iam_role_name, null)
   infrastructure_iam_role_use_name_prefix = try(each.value.infrastructure_iam_role_use_name_prefix, true)

--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -225,7 +225,7 @@ resource "aws_ecs_service" "this" {
         for_each = try([volume_configuration.value.managed_ebs_volume], [])
 
         content {
-          role_arn         = try(aws_iam_role.infrastructure_iam_role[0].arn, var.infrastructure_iam_role_arn)
+          role_arn         = local.infrastructure_iam_role_arn
           encrypted        = try(managed_ebs_volume.value.encrypted, null)
           file_system_type = try(managed_ebs_volume.value.file_system_type, null)
           iops             = try(managed_ebs_volume.value.iops, null)
@@ -1507,6 +1507,7 @@ resource "aws_security_group_rule" "this" {
 locals {
   needs_infrastructure_iam_role  = length(var.volume_configuration) > 0
   create_infrastructure_iam_role = var.create && var.create_infrastructure_iam_role && local.needs_infrastructure_iam_role
+  infrastructure_iam_role_arn    = local.needs_infrastructure_iam_role ? try(aws_iam_role.infrastructure_iam_role[0].arn, var.infrastructure_iam_role_arn) : null
   infrastructure_iam_role_name   = try(coalesce(var.infrastructure_iam_role_name, var.name), "")
 }
 

--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -1505,7 +1505,7 @@ resource "aws_security_group_rule" "this" {
 ############################################################################################
 
 locals {
-  needs_infrastructure_iam_role  = var.volume_configuration != null
+  needs_infrastructure_iam_role  = length(var.volume_configuration) > 0
   create_infrastructure_iam_role = var.create && var.create_infrastructure_iam_role && local.needs_infrastructure_iam_role
   infrastructure_iam_role_name   = try(coalesce(var.infrastructure_iam_role_name, var.name), "")
 }

--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -254,7 +254,8 @@ resource "aws_ecs_service" "this" {
 
   depends_on = [
     aws_iam_role_policy_attachment.service,
-    aws_iam_role_policy_attachment.infrastructure_iam_role_ebs_policy
+    aws_iam_role_policy_attachment.infrastructure_iam_role_ebs_policy,
+    aws_iam_role.infrastructure_iam_role,
   ]
 
   lifecycle {


### PR DESCRIPTION
## Description
@bryantbiggs sorry for the iteration, but #223 merged in before I could push another fix to the infra role logic.

## Motivation and Context
`volume_configuration` variable is defaulted to `{}`, which the `null` check will never work.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
