### PR TITLE
fix: config syntax of service connect tls

### DIFF
--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -181,13 +181,8 @@ resource "aws_ecs_service" "this" {
             for_each = try([service.value.tls], [])
 
             content {
-
-              dynamic "issuer_cert_authority" {
-                for_each = tls.value.issuer_cert_authority
-
-                content {
-                  aws_pca_authority_arn = issuer_cert_authority.value.aws_pca_authority_arn
-                }
+              issuer_cert_authority {
+                aws_pca_authority_arn = tls.value.issuer_cert_authority.aws_pca_authority_arn
               }
 
               kms_key  = try(tls.value.kms_key, null)
@@ -422,13 +417,8 @@ resource "aws_ecs_service" "ignore_task_definition" {
             for_each = try([service.value.tls], [])
 
             content {
-
-              dynamic "issuer_cert_authority" {
-                for_each = tls.value.issuer_cert_authority
-
-                content {
-                  aws_pca_authority_arn = issuer_cert_authority.value.aws_pca_authority_arn
-                }
+              issuer_cert_authority {
+                aws_pca_authority_arn = tls.value.issuer_cert_authority.aws_pca_authority_arn
               }
 
               kms_key  = try(tls.value.kms_key, null)


### PR DESCRIPTION
## Description

Rebound on #216's tls config change.

## Motivation and Context

With the #216 patch I needed to specify a config like this (note double `aws_pca_authority_arn` keys):

```
module "example" {
  source = "terraform-aws-modules/ecs/aws"
  
  # ...
  service_connect_configuration = {
      # ...
      tls = {
        issuer_cert_authority = {
          "aws_pca_authority_arn" = {
            "aws_pca_authority_arn = aws_acmpca_certificate_authority.this.arn
          }
        }
        role_arn = aws_iam_role.service_connect_tls.arn
      }
    }
  }
}
```

But I would expect it to look more like this:

```
module "example" {
  source = "terraform-aws-modules/ecs/aws"
  
  # ...
  service_connect_configuration = {
      # ...
      tls = {
        issuer_cert_authority = {
          "aws_pca_authority_arn" = aws_acmpca_certificate_authority.this.arn
        }
        role_arn = aws_iam_role.service_connect_tls.arn
      }
    }
  }
}
```

But a configuration like the above with the #216 patch yields:

```
Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: Unsupported attribute
│ 
│   on ../../modules/terraform-aws-ecs/modules/service/main.tf line 180, in resource "aws_ecs_service" "this":
│  180:                   aws_pca_authority_arn = issuer_cert_authority.value.aws_pca_authority_arn
│     ├────────────────
│     │ issuer_cert_authority.value is "arn:aws:acm-pca:us-east-1:xxxxxxxxxxxx:certificate-authority/6c2a379a-xxxx-yyyy-zzzz-498531b3dec0"
│ 
│ Can't access attributes on a primitive-typed value (string).

```

## Breaking Changes

The original tls change has only landed in [wip/v6](https://github.com/terraform-aws-modules/terraform-aws-ecs/tree/wip/v6).

## How Has This Been Tested?

It has not. 

Sorry about the brevity, I can't give this the attention it deserves to drive it all the way home right now. But hopefully, this will help save someone some time down the line. Appreciate you guys building this module -- and for the original TLS change :raised_hands: 