### PR TITLE
feat: Add configure_at_launch option for volume block

### DIFF
--- a/examples/fargate/main.tf
+++ b/examples/fargate/main.tf
@@ -191,6 +191,11 @@ module "ecs_task_definition" {
   # Task Definition
   volume = {
     ex-vol = {}
+    ex-vol2 = {
+      host_path = "/tmp"
+      # Only one volume can be configured at launch
+      configure_at_launch = true
+    }
   }
 
   runtime_platform = {

--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -733,8 +733,9 @@ resource "aws_ecs_task_definition" "this" {
         }
       }
 
-      host_path = try(volume.value.host_path, null)
-      name      = try(volume.value.name, volume.key)
+      host_path           = try(volume.value.host_path, null)
+      name                = try(volume.value.name, volume.key)
+      configure_at_launch = try(volume.value.configure_at_launch, null)
     }
   }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The `configure_at_launch` option is missing for volume configuration.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It adds the option to configure the volume at launch.
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [X] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
