### PR TITLE
fix: Use only the defined default capacity provider strategies.

### DIFF
--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -109,8 +109,8 @@ resource "aws_cloudwatch_log_group" "this" {
 
 locals {
   default_capacity_providers = merge(
-    { for k, v in var.fargate_capacity_providers : k => v if var.default_capacity_provider_use_fargate },
-    { for k, v in var.autoscaling_capacity_providers : k => v if !var.default_capacity_provider_use_fargate }
+    { for k, v in var.fargate_capacity_providers : k => v if var.default_capacity_provider_use_fargate && lookup(v, "default_capacity_provider_strategy", null) != null },
+    { for k, v in var.autoscaling_capacity_providers : k => v if !var.default_capacity_provider_use_fargate && lookup(v, "default_capacity_provider_strategy", null) != null }
   )
 }
 


### PR DESCRIPTION
## Description
An ECS Cluster can have up to 4 default capacity provider strategies. The previous logic would add every capacity provider defined for either EC2 or Fargate. Update the logic to only set a default strategy if the capacity provider sets the default_capacity_provider_strategy map.

## Motivation and Context
When using > 4 EC2 ASGs, the module fails due to generating too many default capacity provider strategy rules. Additionally, there can be capacity providers one wouldn't want in the default strategy for a cluster.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
Only breaks if `default_capacity_provider_strategy` isn't being set on at least one of the entries in the `autoscaling_capacity_providers` or `fargate_capacity_providers` maps.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
