### PR TITLE
chore: Update variable name to tag_specifications

### DIFF
--- a/modules/service/variables.tf
+++ b/modules/service/variables.tf
@@ -283,7 +283,7 @@ variable "volume_configuration" {
       snapshot_id      = optional(string)
       throughput       = optional(number)
       volume_type      = optional(string)
-      tag_specification = optional(list(object({
+      tag_specifications = optional(list(object({
         resource_type  = string
         propagate_tags = optional(string, "TASK_DEFINITION")
         tags           = optional(map(string))


### PR DESCRIPTION
In service/main.tf it is used a plural tag_specifications name for the attribute

## Description
In the service it is used reference for a plural tag_specifications but in variables.tf the variable name is singular tag_specifications, this makes the deployment to break, after changing to plural it works again.

In file modules/service/variables.tf we have singular tag_specification
https://github.com/terraform-aws-modules/terraform-aws-ecs/blob/bf5bdcd4403951831d27177d0f44c3ff3d2599aa/modules/service/variables.tf#L286


But in modules/service/main.tf we have plural tag_specifications
https://github.com/terraform-aws-modules/terraform-aws-ecs/blob/bf5bdcd4403951831d27177d0f44c3ff3d2599aa/modules/service/main.tf#L245
```
          dynamic "tag_specifications" {
            for_each = managed_ebs_volume.value.tag_specifications != null ? managed_ebs_volume.value.tag_specifications : []

            content {
              resource_type  = tag_specifications.value.resource_type
              propagate_tags = tag_specifications.value.propagate_tags
              tags           = tag_specifications.value.tags
            }
          }
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I deployed an application using the new configuration