### PR TITLE
feat: Change to use of managed IAM policy for ecs tasks with path attribute support over inline role policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -148,6 +148,7 @@ module "service" {
   tasks_iam_role_description          = try(each.value.tasks_iam_role_description, null)
   tasks_iam_role_permissions_boundary = try(each.value.tasks_iam_role_permissions_boundary, null)
   tasks_iam_role_tags                 = try(each.value.tasks_iam_role_tags, {})
+  tasks_iam_policy_path               = try(each.value.tasks_iam_policy_path, null)
   tasks_iam_role_policies             = lookup(each.value, "tasks_iam_role_policies", {})
   tasks_iam_role_statements           = lookup(each.value, "tasks_iam_role_statements", {})
 

--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -1024,13 +1024,22 @@ data "aws_iam_policy_document" "tasks" {
   }
 }
 
-resource "aws_iam_role_policy" "tasks" {
+resource "aws_iam_policy" "tasks" {
   count = local.create_tasks_iam_role && (length(var.tasks_iam_role_statements) > 0 || var.enable_execute_command) ? 1 : 0
 
   name        = var.tasks_iam_role_use_name_prefix ? null : local.tasks_iam_role_name
   name_prefix = var.tasks_iam_role_use_name_prefix ? "${local.tasks_iam_role_name}-" : null
+  description = coalesce(var.tasks_iam_role_description, "Task role IAM policy")
   policy      = data.aws_iam_policy_document.tasks[0].json
-  role        = aws_iam_role.tasks[0].id
+  path        = var.tasks_iam_policy_path
+  tags        = merge(var.tags, var.tasks_iam_role_tags)
+}
+
+resource "aws_iam_role_policy_attachment" "tasks_policy" {
+  count = local.create_tasks_iam_role && (length(var.tasks_iam_role_statements) > 0 || var.enable_execute_command) ? 1 : 0
+
+  role       = aws_iam_role.tasks[0].name
+  policy_arn = aws_iam_policy.tasks[0].arn
 }
 
 ################################################################################

--- a/modules/service/variables.tf
+++ b/modules/service/variables.tf
@@ -539,6 +539,12 @@ variable "tasks_iam_role_statements" {
   default     = {}
 }
 
+variable "tasks_iam_policy_path" {
+  description = "Path for the tasks iam policy"
+  type        = string
+  default     = null
+}
+
 ################################################################################
 # Task Set
 ################################################################################


### PR DESCRIPTION
## Description
The following changes are proposed:
- Change the ECS tasks role policy to be managed as a separate `aws_iam_policy` resource rather than the inline type `aws_iam_role_policy`
- Add explicit role policy attachment to attach the managed ECS tasks policy to the role.
- Add support for specifying `path` of the ECS tasks policy.

## Motivation and Context
The change opens for more flexibility in the ECS tasks role for specifying the path of the policy.
This also aligns the ECS tasks role and policy with the same pattern that the existing role and policy for the ECS task execution role in the module.

## Breaking Changes
- If ECS task role is not used (i.e. conditions for creating task role is not met), no changes will be picked up by Terraform.
- If ECS task role is used (i.e. conditions for creating task role is not met), the inline iam role policy will be replaced by the iam policy and role policy attachment.

Both cases applies both with or without the path configuration of the policy being set with the new variable `tasks_iam_policy_path`.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using the `examples/complete` project deployed cleanly first, with later addition of ecs service variable input of `tasks_iam_policy_path` prompting to take the changes into effect. The changes was deployed sucessfully.
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
