### PR TITLE
feat: Change to managed IAM policy for ecs tasks with path attrribute support over inline role policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [5.12.0](https://github.com/terraform-aws-modules/terraform-aws-ecs/compare/v5.11.4...v5.12.0) (2024-11-29)
+
+
+### Features
+
+* Allow task exec IAM policy to have an IAM path ([#243](https://github.com/terraform-aws-modules/terraform-aws-ecs/issues/243)) ([c9dc889](https://github.com/terraform-aws-modules/terraform-aws-ecs/commit/c9dc889a4b081105fb7567ca12a2d32ac36caa29))
+
+
+### Bug Fixes
+
+* Update CI workflow versions to latest ([#236](https://github.com/terraform-aws-modules/terraform-aws-ecs/issues/236)) ([fd0f0ec](https://github.com/terraform-aws-modules/terraform-aws-ecs/commit/fd0f0ecd7fd3a85d8d738320d37a22644b5f129a))
+
 ## [5.11.4](https://github.com/terraform-aws-modules/terraform-aws-ecs/compare/v5.11.3...v5.11.4) (2024-08-07)
 
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -62,6 +62,7 @@ No inputs.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_alb_dns_name"></a> [alb\_dns\_name](#output\_alb\_dns\_name) | The DNS name of the load balancer |
 | <a name="output_cluster_arn"></a> [cluster\_arn](#output\_cluster\_arn) | ARN that identifies the cluster |
 | <a name="output_cluster_autoscaling_capacity_providers"></a> [cluster\_autoscaling\_capacity\_providers](#output\_cluster\_autoscaling\_capacity\_providers) | Map of capacity providers created and their attributes |
 | <a name="output_cluster_capacity_providers"></a> [cluster\_capacity\_providers](#output\_cluster\_capacity\_providers) | Map of cluster capacity providers attributes |

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -35,3 +35,12 @@ output "services" {
   description = "Map of services created and their attributes"
   value       = module.ecs.services
 }
+
+################################################################################
+# Application Load Balancer
+################################################################################
+
+output "alb_dns_name" {
+  description = "The DNS name of the load balancer"
+  value       = module.alb.dns_name
+}

--- a/examples/ec2-autoscaling/README.md
+++ b/examples/ec2-autoscaling/README.md
@@ -61,6 +61,7 @@ No inputs.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_alb_dns_name"></a> [alb\_dns\_name](#output\_alb\_dns\_name) | The DNS name of the load balancer |
 | <a name="output_cluster_arn"></a> [cluster\_arn](#output\_cluster\_arn) | ARN that identifies the cluster |
 | <a name="output_cluster_autoscaling_capacity_providers"></a> [cluster\_autoscaling\_capacity\_providers](#output\_cluster\_autoscaling\_capacity\_providers) | Map of capacity providers created and their attributes |
 | <a name="output_cluster_capacity_providers"></a> [cluster\_capacity\_providers](#output\_cluster\_capacity\_providers) | Map of cluster capacity providers attributes |

--- a/examples/ec2-autoscaling/outputs.tf
+++ b/examples/ec2-autoscaling/outputs.tf
@@ -130,3 +130,12 @@ output "service_autoscaling_scheduled_actions" {
   description = "Map of autoscaling scheduled actions and their attributes"
   value       = module.ecs_service.autoscaling_scheduled_actions
 }
+
+################################################################################
+# Application Load Balancer
+################################################################################
+
+output "alb_dns_name" {
+  description = "The DNS name of the load balancer"
+  value       = module.alb.dns_name
+}

--- a/examples/fargate/main.tf
+++ b/examples/fargate/main.tf
@@ -185,8 +185,9 @@ module "ecs_task_definition" {
   source = "../../modules/service"
 
   # Service
-  name        = "${local.name}-standalone"
-  cluster_arn = module.ecs_cluster.arn
+  name           = "${local.name}-standalone"
+  cluster_arn    = module.ecs_cluster.arn
+  create_service = false
 
   # Task Definition
   volume = {

--- a/modules/container-definition/README.md
+++ b/modules/container-definition/README.md
@@ -4,7 +4,7 @@ Configuration in this directory creates an Amazon ECS container definition.
 
 The module defaults to creating and utilizing a CloudWatch log group. You can disable this behavior by setting `enable_cloudwatch_logging` = `false` - useful for scenarios where Firelens is used for log forwarding.
 
-For more details see the [design doc](https://github.com/terraform-aws-modules/terraform-aws-ecs/blob/master/docs/design.md)
+For more details see the [design doc](https://github.com/terraform-aws-modules/terraform-aws-ecs/blob/master/docs/README.md)
 
 ## Usage
 

--- a/modules/service/README.md
+++ b/modules/service/README.md
@@ -294,6 +294,7 @@ module "ecs_service" {
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 | <a name="input_task_definition_arn"></a> [task\_definition\_arn](#input\_task\_definition\_arn) | Existing task definition ARN. Required when `create_task_definition` is `false` | `string` | `null` | no |
 | <a name="input_task_definition_placement_constraints"></a> [task\_definition\_placement\_constraints](#input\_task\_definition\_placement\_constraints) | Configuration block for rules that are taken into consideration during task placement (up to max of 10). This is set at the task definition, see `placement_constraints` for setting at the service | `any` | `{}` | no |
+| <a name="input_task_exec_iam_policy_path"></a> [task\_exec\_iam\_policy\_path](#input\_task\_exec\_iam\_policy\_path) | Path for the iam role | `string` | `null` | no |
 | <a name="input_task_exec_iam_role_arn"></a> [task\_exec\_iam\_role\_arn](#input\_task\_exec\_iam\_role\_arn) | Existing IAM role ARN | `string` | `null` | no |
 | <a name="input_task_exec_iam_role_description"></a> [task\_exec\_iam\_role\_description](#input\_task\_exec\_iam\_role\_description) | Description of the role | `string` | `null` | no |
 | <a name="input_task_exec_iam_role_max_session_duration"></a> [task\_exec\_iam\_role\_max\_session\_duration](#input\_task\_exec\_iam\_role\_max\_session\_duration) | Maximum session duration (in seconds) for ECS task execution role. Default is 3600. | `number` | `null` | no |

--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -894,8 +894,8 @@ resource "aws_iam_policy" "task_exec" {
   name_prefix = var.task_exec_iam_role_use_name_prefix ? "${local.task_exec_iam_role_name}-" : null
   description = coalesce(var.task_exec_iam_role_description, "Task execution role IAM policy")
   policy      = data.aws_iam_policy_document.task_exec[0].json
-
-  tags = merge(var.tags, var.task_exec_iam_role_tags)
+  path        = var.task_exec_iam_policy_path
+  tags        = merge(var.tags, var.task_exec_iam_role_tags)
 }
 
 resource "aws_iam_role_policy_attachment" "task_exec" {

--- a/modules/service/variables.tf
+++ b/modules/service/variables.tf
@@ -468,6 +468,12 @@ variable "task_exec_iam_statements" {
   default     = {}
 }
 
+variable "task_exec_iam_policy_path" {
+  description = "Path for the iam role"
+  type        = string
+  default     = null
+}
+
 ################################################################################
 # Tasks - IAM role
 # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html

--- a/wrappers/service/main.tf
+++ b/wrappers/service/main.tf
@@ -98,6 +98,7 @@ module "wrapper" {
   tags                                    = try(each.value.tags, var.defaults.tags, {})
   task_definition_arn                     = try(each.value.task_definition_arn, var.defaults.task_definition_arn, null)
   task_definition_placement_constraints   = try(each.value.task_definition_placement_constraints, var.defaults.task_definition_placement_constraints, {})
+  task_exec_iam_policy_path               = try(each.value.task_exec_iam_policy_path, var.defaults.task_exec_iam_policy_path, null)
   task_exec_iam_role_arn                  = try(each.value.task_exec_iam_role_arn, var.defaults.task_exec_iam_role_arn, null)
   task_exec_iam_role_description          = try(each.value.task_exec_iam_role_description, var.defaults.task_exec_iam_role_description, null)
   task_exec_iam_role_max_session_duration = try(each.value.task_exec_iam_role_max_session_duration, var.defaults.task_exec_iam_role_max_session_duration, null)


### PR DESCRIPTION
## Description
The following changes are proposed:
- Change the ECS tasks role policy to be managed as a separate `aws_iam_policy` resource rather than the inline type `aws_iam_role_policy`
- Add explicit role policy attachment to attach the managed ECS tasks policy to the role.
- Add support for specifying `path` of the ECS tasks policy.

## Motivation and Context
The change opens for more flexibility in the ECS tasks role for specifying the path of the policy.
This also aligns the ECS tasks role and policy with the same pattern that the existing role and policy for the ECS task execution role in the module.

## Breaking Changes
- If ECS task role is not used (i.e. conditions for creating task role is not met), no changes will be picked up by Terraform.
- If ECS task role is used (i.e. conditions for creating task role is not met), the inline iam role policy will be replaced by the iam policy and role policy attachment.

Both cases applies both with or without the path configuration of the policy being set with the new variable `tasks_iam_policy_path`.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using the `examples/complete` project deployed cleanly first, with later addition of ecs service variable input of `tasks_iam_policy_path` prompting to take the changes into effect. The changes was deployed sucessfully.
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
