### PR TITLE
feat: TLS configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ No resources.
 | <a name="input_create_task_exec_policy"></a> [create\_task\_exec\_policy](#input\_create\_task\_exec\_policy) | Determines whether the ECS task definition IAM policy should be created. This includes permissions included in AmazonECSTaskExecutionRolePolicy as well as access to secrets and SSM parameters | `bool` | `true` | no |
 | <a name="input_default_capacity_provider_use_fargate"></a> [default\_capacity\_provider\_use\_fargate](#input\_default\_capacity\_provider\_use\_fargate) | Determines whether to use Fargate or autoscaling for default capacity provider strategy | `bool` | `true` | no |
 | <a name="input_fargate_capacity_providers"></a> [fargate\_capacity\_providers](#input\_fargate\_capacity\_providers) | Map of Fargate capacity provider definitions to use for the cluster | `any` | `{}` | no |
+| <a name="input_managed_storage_configuration"></a> [managed\_storage\_configuration](#input\_managed\_storage\_configuration) | Configuration for the managed storage | `any` | `{}` | no |
 | <a name="input_services"></a> [services](#input\_services) | Map of service definitions to create | `any` | `{}` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 | <a name="input_task_exec_iam_role_description"></a> [task\_exec\_iam\_role\_description](#input\_task\_exec\_iam\_role\_description) | Description of the role | `string` | `null` | no |

--- a/examples/fargate/README.md
+++ b/examples/fargate/README.md
@@ -43,12 +43,14 @@ Note that this example may create resources which will incur monetary charges on
 | <a name="module_ecs_cluster"></a> [ecs\_cluster](#module\_ecs\_cluster) | ../../modules/cluster | n/a |
 | <a name="module_ecs_service"></a> [ecs\_service](#module\_ecs\_service) | ../../modules/service | n/a |
 | <a name="module_ecs_task_definition"></a> [ecs\_task\_definition](#module\_ecs\_task\_definition) | ../../modules/service | n/a |
+| <a name="module_tls_role"></a> [tls\_role](#module\_tls\_role) | terraform-aws-modules/iam/aws//modules/iam-assumable-role | 5.41.0 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 5.0 |
 
 ## Resources
 
 | Name | Type |
 |------|------|
+| [aws_acmpca_certificate_authority.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acmpca_certificate_authority) | resource |
 | [aws_service_discovery_http_namespace.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/service_discovery_http_namespace) | resource |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_ssm_parameter.fluentbit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |

--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ module "cluster" {
   cluster_configuration            = var.cluster_configuration
   cluster_settings                 = var.cluster_settings
   cluster_service_connect_defaults = var.cluster_service_connect_defaults
-
+  managed_storage_configuration    = var.managed_storage_configuration
   # Cluster Cloudwatch log group
   create_cloudwatch_log_group            = var.create_cloudwatch_log_group
   cloudwatch_log_group_name              = var.cloudwatch_log_group_name

--- a/modules/cluster/README.md
+++ b/modules/cluster/README.md
@@ -181,6 +181,7 @@ No modules.
 | <a name="input_create_task_exec_policy"></a> [create\_task\_exec\_policy](#input\_create\_task\_exec\_policy) | Determines whether the ECS task definition IAM policy should be created. This includes permissions included in AmazonECSTaskExecutionRolePolicy as well as access to secrets and SSM parameters | `bool` | `true` | no |
 | <a name="input_default_capacity_provider_use_fargate"></a> [default\_capacity\_provider\_use\_fargate](#input\_default\_capacity\_provider\_use\_fargate) | Determines whether to use Fargate or autoscaling for default capacity provider strategy | `bool` | `true` | no |
 | <a name="input_fargate_capacity_providers"></a> [fargate\_capacity\_providers](#input\_fargate\_capacity\_providers) | Map of Fargate capacity provider definitions to use for the cluster | `any` | `{}` | no |
+| <a name="input_managed_storage_configuration"></a> [managed\_storage\_configuration](#input\_managed\_storage\_configuration) | Configuration for the managed storage | `any` | `{}` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 | <a name="input_task_exec_iam_role_description"></a> [task\_exec\_iam\_role\_description](#input\_task\_exec\_iam\_role\_description) | Description of the role | `string` | `null` | no |
 | <a name="input_task_exec_iam_role_name"></a> [task\_exec\_iam\_role\_name](#input\_task\_exec\_iam\_role\_name) | Name to use on IAM role created | `string` | `null` | no |

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -40,6 +40,15 @@ resource "aws_ecs_cluster" "this" {
           }
         }
       }
+
+      dynamic "managed_storage_configuration" {
+        for_each = try([var.managed_storage_configuration], [])
+
+        content {
+          fargate_ephemeral_storage_kms_key_id = try(managed_storage_configuration.value.fargate_ephemeral_storage_kms_key_id, null)
+          kms_key_id                           = try(managed_storage_configuration.value.kms_key_id, null)
+        }
+      }
     }
   }
 
@@ -65,6 +74,15 @@ resource "aws_ecs_cluster" "this" {
               s3_key_prefix                  = try(log_configuration.value.s3_key_prefix, null)
             }
           }
+        }
+      }
+
+      dynamic "managed_storage_configuration" {
+        for_each = try([var.managed_storage_configuration], [])
+
+        content {
+          fargate_ephemeral_storage_kms_key_id = try(managed_storage_configuration.value.fargate_ephemeral_storage_kms_key_id, null)
+          kms_key_id                           = try(managed_storage_configuration.value.kms_key_id, null)
         }
       }
     }

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -43,6 +43,12 @@ variable "cluster_service_connect_defaults" {
   default     = {}
 }
 
+variable "managed_storage_configuration" {
+  description = "Configuration for the managed storage"
+  type        = any
+  default     = {}
+}
+
 ################################################################################
 # CloudWatch Log Group
 ################################################################################

--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -172,7 +172,7 @@ resource "aws_ecs_service" "this" {
             for_each = try([service.value.tls], [])
 
             content {
-              kms_key = try(tls.value.kms_key, null)
+              kms_key  = try(tls.value.kms_key, null)
               role_arn = try(tls.value.role_arn, null)
               issuer_cert_authority {
                 aws_pca_authority_arn = try(tls.value.issuer_cert_authority.aws_pca_authority_arn, null)
@@ -372,7 +372,7 @@ resource "aws_ecs_service" "ignore_task_definition" {
             for_each = try([service.value.tls], [])
 
             content {
-              kms_key = try(tls.value.kms_key, null)
+              kms_key  = try(tls.value.kms_key, null)
               role_arn = try(tls.value.role_arn, null)
               issuer_cert_authority {
                 aws_pca_authority_arn = try(tls.value.issuer_cert_authority.aws_pca_authority_arn, null)

--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -168,6 +168,18 @@ resource "aws_ecs_service" "this" {
             }
           }
 
+          dynamic "tls" {
+            for_each = try([service.value.tls], [])
+
+            content {
+              kms_key = try(tls.value.kms_key, null)
+              role_arn = try(tls.value.role_arn, null)
+              issuer_cert_authority {
+                aws_pca_authority_arn = try(tls.value.issuer_cert_authority.aws_pca_authority_arn, null)
+              }
+            }
+          }
+
           discovery_name        = try(service.value.discovery_name, null)
           ingress_port_override = try(service.value.ingress_port_override, null)
           port_name             = service.value.port_name

--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -368,6 +368,18 @@ resource "aws_ecs_service" "ignore_task_definition" {
             }
           }
 
+          dynamic "tls" {
+            for_each = try([service.value.tls], [])
+
+            content {
+              kms_key = try(tls.value.kms_key, null)
+              role_arn = try(tls.value.role_arn, null)
+              issuer_cert_authority {
+                aws_pca_authority_arn = try(tls.value.issuer_cert_authority.aws_pca_authority_arn, null)
+              }
+            }
+          }
+
           discovery_name        = try(service.value.discovery_name, null)
           ingress_port_override = try(service.value.ingress_port_override, null)
           port_name             = service.value.port_name

--- a/variables.tf
+++ b/variables.tf
@@ -49,6 +49,12 @@ variable "cluster_tags" {
   default     = {}
 }
 
+variable "managed_storage_configuration" {
+  description = "Configuration for the managed storage"
+  type        = any
+  default     = {}
+}
+
 ################################################################################
 # CloudWatch Log Group
 ################################################################################

--- a/wrappers/cluster/main.tf
+++ b/wrappers/cluster/main.tf
@@ -23,6 +23,7 @@ module "wrapper" {
   create_task_exec_policy                 = try(each.value.create_task_exec_policy, var.defaults.create_task_exec_policy, true)
   default_capacity_provider_use_fargate   = try(each.value.default_capacity_provider_use_fargate, var.defaults.default_capacity_provider_use_fargate, true)
   fargate_capacity_providers              = try(each.value.fargate_capacity_providers, var.defaults.fargate_capacity_providers, {})
+  managed_storage_configuration           = try(each.value.managed_storage_configuration, var.defaults.managed_storage_configuration, {})
   tags                                    = try(each.value.tags, var.defaults.tags, {})
   task_exec_iam_role_description          = try(each.value.task_exec_iam_role_description, var.defaults.task_exec_iam_role_description, null)
   task_exec_iam_role_name                 = try(each.value.task_exec_iam_role_name, var.defaults.task_exec_iam_role_name, null)

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -24,6 +24,7 @@ module "wrapper" {
   create_task_exec_policy                 = try(each.value.create_task_exec_policy, var.defaults.create_task_exec_policy, true)
   default_capacity_provider_use_fargate   = try(each.value.default_capacity_provider_use_fargate, var.defaults.default_capacity_provider_use_fargate, true)
   fargate_capacity_providers              = try(each.value.fargate_capacity_providers, var.defaults.fargate_capacity_providers, {})
+  managed_storage_configuration           = try(each.value.managed_storage_configuration, var.defaults.managed_storage_configuration, {})
   services                                = try(each.value.services, var.defaults.services, {})
   tags                                    = try(each.value.tags, var.defaults.tags, {})
   task_exec_iam_role_description          = try(each.value.task_exec_iam_role_description, var.defaults.task_exec_iam_role_description, null)


### PR DESCRIPTION
## Description
Allow configuration of [TLS](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service#tls-1) for the ECS service.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
No breaking changes

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
