### PR TITLE
feat: Support custom service connect timeout

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -114,6 +114,10 @@ module "ecs" {
           }
           port_name      = local.container_name
           discovery_name = local.container_name
+          timeout = {
+            idle_timeout_seconds        = 60
+            per_request_timeout_seconds = 60
+          }
         }
       }
 

--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -168,6 +168,15 @@ resource "aws_ecs_service" "this" {
             }
           }
 
+          dynamic "timeout" {
+            for_each = try([service.value.timeout], [])
+
+            content {
+              idle_timeout_seconds        = try(service.value.timeout.idle_timeout_seconds, null)
+              per_request_timeout_seconds = try(service.value.timeout.per_request_timeout_seconds, null)
+            }
+          }
+
           discovery_name        = try(service.value.discovery_name, null)
           ingress_port_override = try(service.value.ingress_port_override, null)
           port_name             = service.value.port_name


### PR DESCRIPTION
## Description
Added support for custom service connect timeouts

## Motivation and Context

In some cases services need more than 15 seconds of connectivity or want to completely turn off idle connections.

## Breaking Changes

Not that I'm aware of.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects

I used a local change project

- [x] I have executed `pre-commit run -a` on my pull request

this generated a bunch of changes which I didn't commit
