### PR TITLE
fix: Add missing timeout to service module

### DIFF
--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -168,6 +168,15 @@ resource "aws_ecs_service" "this" {
             }
           }
 
+          dynamic "timeout" {
+            for_each = try([service.value.timeout], [])
+
+            content {
+              idle_timeout_seconds        = try(timeout.value.idle_timeout_seconds, null)
+              per_request_timeout_seconds = try(timeout.value.per_request_timeout_seconds, null)
+            }
+          }
+
           discovery_name        = try(service.value.discovery_name, null)
           ingress_port_override = try(service.value.ingress_port_override, null)
           port_name             = service.value.port_name
@@ -353,6 +362,15 @@ resource "aws_ecs_service" "ignore_task_definition" {
             content {
               dns_name = try(client_alias.value.dns_name, null)
               port     = client_alias.value.port
+            }
+          }
+
+          dynamic "timeout" {
+            for_each = try([service.value.timeout], [])
+
+            content {
+              idle_timeout_seconds        = try(timeout.value.idle_timeout_seconds, null)
+              per_request_timeout_seconds = try(timeout.value.per_request_timeout_seconds, null)
             }
           }
 


### PR DESCRIPTION
## Description
Added a new dynamic "timeout" block that supports two timeout-related configurations in `modules/service/main.tf`:
- idle_timeout_seconds: For setting the amount of time in seconds a connection will stay active while idle.
- per_request_timeout_seconds: For setting the amount of time in seconds for the upstream to respond with a complete response per request.

## Motivation and Context
It was not possible to set timeout ECS Service Connect configuration.

## Breaking Changes
No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
