### PR TITLE
feat: Added managed storage KMS configuration

### DIFF
--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -40,6 +40,15 @@ resource "aws_ecs_cluster" "this" {
           }
         }
       }
+
+      dynamic "managed_storage_configuration" {
+        for_each = try([configuration.value.managed_storage_configuration], [{}])
+
+        content {
+          kms_key_id                           = try(managed_storage_configuration.value.kms_key_id, null)
+          fargate_ephemeral_storage_kms_key_id = try(managed_storage_configuration.value.fargate_ephemeral_storage_kms_key_id, null)
+        }
+      }
     }
   }
 
@@ -65,6 +74,15 @@ resource "aws_ecs_cluster" "this" {
               s3_key_prefix                  = try(log_configuration.value.s3_key_prefix, null)
             }
           }
+        }
+      }
+
+      dynamic "managed_storage_configuration" {
+        for_each = try([configuration.value.managed_storage_configuration], [{}])
+
+        content {
+          kms_key_id                           = try(managed_storage_configuration.value.kms_key_id, null)
+          fargate_ephemeral_storage_kms_key_id = try(managed_storage_configuration.value.fargate_ephemeral_storage_kms_key_id, null)
         }
       }
     }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.66.1"
+      version = ">= 5.59.0"
     }
   }
 }


### PR DESCRIPTION
## Description
The changes primarily focus on adding support for managed storage configuration and updating the required AWS provider version.

### Managed Storage Configuration:
* Added a dynamic block for `managed_storage_configuration` in the `aws_ecs_cluster` resource to handle optional managed storage settings, including `kms_key_id` and `fargate_ephemeral_storage_kms_key_id`.

### Provider Version Update:

* Updated the required version of the AWS provider from `>= 4.66.1` to `>= 5.59.0` to ensure compatibility with empheral storage configuration.

Fixes issue #258 
