### PR TITLE
fix: Ensure both ECS service definitions use the same settings/configurations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.96.1
+    rev: v1.99.0
     hooks:
       - id: terraform_fmt
       - id: terraform_wrapper_module_for_each

--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -381,7 +381,7 @@ resource "aws_ecs_service" "ignore_task_definition" {
   wait_for_steady_state = var.wait_for_steady_state
 
   propagate_tags = var.propagate_tags
-  tags           = var.tags
+  tags           = merge(var.tags, var.service_tags)
 
   timeouts {
     create = try(var.timeouts.create, null)

--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -285,7 +285,7 @@ resource "aws_ecs_service" "ignore_task_definition" {
 
   dynamic "network_configuration" {
     # Set by task set if deployment controller is external
-    for_each = var.network_mode == "awsvpc" ? [{ for k, v in local.network_configuration : k => v if !local.is_external_deployment }] : []
+    for_each = var.network_mode == "awsvpc" && !local.is_external_deployment ? [local.network_configuration] : []
 
     content {
       assign_public_ip = network_configuration.value.assign_public_ip


### PR DESCRIPTION
This fixes the issue specifically with the `ignore_task_definition` service type.

## Description

This change ensures that ECS service tags are properly applied when using the `ignore_task_definition` service configuration. Previously, only `var.tags` were used, which caused `var.service_tags` to be ignored entirely for this resource.

The following change was made:

```hcl
- tags = var.tags
+ tags = merge(var.tags, var.service_tags)
```


## Motivation and Context

Currently, when using `ignore_task_definition = true`, the ECS service resource does not receive any tags defined in `var.service_tags`. 

There is no open issue for this, but the fix is straightforward and consistent with tagging patterns used elsewhere in the module.

## Breaking Changes
No breaking changes.

## How Has This Been Tested?
- [x] I tested and validated it by updating the `modules/service/main.tf` logic to correctly merge tags on my own terraform module, which references this module as its source. Service tags worked properly only after the change.
- [x] I have also tested and validated using the provided example in `terraform-aws-ecs/examples/fargate/main.tf`, changing only the following:
in locals :`region = "us-east-1"`,
in module "ecs_service":     ignore_task_definition_changes = true,
I tested following the order/logic of the commits here https://github.com/will-abb/terraform-aws-ecs/tree/test-service-tags-not-progagated
- [x] I have executed `pre-commit run -a` on my pull request
I get some formatting changes when I run the commit, but I think that's due to my local linux environment. But I could be wrong and can include the changes made by the pre-commit, but they appear to be just noise.
