### PR TITLE
feat: Add version consistency support in container definition

### DIFF
--- a/modules/container-definition/README.md
+++ b/modules/container-definition/README.md
@@ -139,7 +139,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_cloudwatch_log_group_kms_key_id"></a> [cloudwatch\_log\_group\_kms\_key\_id](#input\_cloudwatch\_log\_group\_kms\_key\_id) | If a KMS Key ARN is set, this key will be used to encrypt the corresponding log group. Please be sure that the KMS Key has an appropriate key policy (https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html) | `string` | `null` | no |
+| <a name="input_cloudwatch_log_group_kms_key_id"></a> [cloudwatch\_log\_group\_kms\_key\_id](#input\_cloudwatch\_log\_group\_kms\_key\_id) | If a KMS Key ARN is set, this key will be used to encrypt the corresponding log group. Please be sure that the KMS Key has an appropriate key policy (<https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html>) | `string` | `null` | no |
 | <a name="input_cloudwatch_log_group_name"></a> [cloudwatch\_log\_group\_name](#input\_cloudwatch\_log\_group\_name) | Custom name of CloudWatch log group for a service associated with the container definition | `string` | `null` | no |
 | <a name="input_cloudwatch_log_group_retention_in_days"></a> [cloudwatch\_log\_group\_retention\_in\_days](#input\_cloudwatch\_log\_group\_retention\_in\_days) | Number of days to retain log events. Default is 30 days | `number` | `30` | no |
 | <a name="input_cloudwatch_log_group_use_name_prefix"></a> [cloudwatch\_log\_group\_use\_name\_prefix](#input\_cloudwatch\_log\_group\_use\_name\_prefix) | Determines whether the log group name should be used as a prefix | `bool` | `false` | no |
@@ -186,6 +186,7 @@ No modules.
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 | <a name="input_ulimits"></a> [ulimits](#input\_ulimits) | A list of ulimits to set in the container. If a ulimit value is specified in a task definition, it overrides the default values set by Docker | <pre>list(object({<br/>    hardLimit = number<br/>    name      = string<br/>    softLimit = number<br/>  }))</pre> | `[]` | no |
 | <a name="input_user"></a> [user](#input\_user) | The user to run as inside the container. Can be any of these formats: user, user:group, uid, uid:gid, user:gid, uid:group. The default (null) will use the container's configured `USER` directive or root if not set | `string` | `null` | no |
+| <a name="input_version_consistency"></a> [version\_consistency](#input\_version\_consistency) | Specifies whether Amazon ECS will resolve the container image tag provided in the container definition to an image digest. The default is `enabled`. If set to `disabled`, Amazon ECS will not resolve the container image tag to a digest (<https://docs.aws.amazon.com/AmazonECS/latest/developerguide/deployment-type-ecs.html#deployment-container-image-stability>). | `string` | `"enabled"` | no |
 | <a name="input_volumes_from"></a> [volumes\_from](#input\_volumes\_from) | Data volumes to mount from another container | `list(any)` | `[]` | no |
 | <a name="input_working_directory"></a> [working\_directory](#input\_working\_directory) | The working directory to run commands inside the container | `string` | `null` | no |
 

--- a/modules/container-definition/main.tf
+++ b/modules/container-definition/main.tf
@@ -65,6 +65,7 @@ locals {
     user                   = local.is_not_windows ? var.user : null
     volumesFrom            = var.volumes_from
     workingDirectory       = var.working_directory
+    versionConsistency     = var.version_consistency
   }
 
   # Strip out all null values, ECS API will provide defaults in place of null/empty values

--- a/modules/container-definition/variables.tf
+++ b/modules/container-definition/variables.tf
@@ -270,6 +270,15 @@ variable "working_directory" {
   default     = null
 }
 
+variable "version_consistency" {
+  description = "Specifies whether Amazon ECS will resolve the container image tag provided in the container definition to an image digest. The default is `enabled`. If set to `disabled`, Amazon ECS will not resolve the container image tag to a digest (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/deployment-type-ecs.html#deployment-container-image-stability)."
+  type        = string
+  validation {
+    condition     = contains(["enabled", "disabled"], var.version_consistency)
+    error_message = "The version consistency must be either `enabled` or `disabled`"
+  }
+  default = "enabled"
+}
 ################################################################################
 # CloudWatch Log Group
 ################################################################################

--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -573,6 +573,7 @@ module "container_definition" {
   user                     = try(each.value.user, var.container_definition_defaults.user, 0)
   volumes_from             = try(each.value.volumes_from, var.container_definition_defaults.volumes_from, [])
   working_directory        = try(each.value.working_directory, var.container_definition_defaults.working_directory, null)
+  version_consistency      = try(each.value.version_consistency, var.container_definition_defaults.version_consistency, "enabled")
 
   # CloudWatch Log Group
   service                                = var.name


### PR DESCRIPTION
## Description
Since November 2024, AWS has added the software version consistency option 

https://aws.amazon.com/about-aws/whats-new/2024/11/amazon-ecs-configure-software-version-consistency/

https://docs.aws.amazon.com/AmazonECS/latest/developerguide/deployment-type-ecs.html#deployment-container-image-stability

## Motivation and Context
To be able to disable version consistency 

## Breaking Changes
None. The default value is "enabled" as described in the doc:
https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#ContainerDefinition-versionconsistency

## How Has This Been Tested?
Tested in a private project (cannot share here)
