### PR TITLE
feat: Added managed storage config

### DIFF
--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -70,6 +70,20 @@ resource "aws_ecs_cluster" "this" {
     }
   }
 
+  dynamic "configuration" {
+    for_each = length(var.cluster_configuration) > 0 ? [var.cluster_configuration] : []
+
+    content {
+      dynamic "managed_storage_configuration" {
+        for_each = try([configuration.value.managed_storage_configuration], [{}])
+        content {
+          fargate_ephemeral_storage_kms_key_id = try(configuration.value.managed_storage_configuration.fargate_ephemeral_storage_kms_key_id, null)
+          kms_key_id = try(configuration.value.managed_storage_configuration.kms_key_id, null)
+        }
+      }
+    }
+  }
+
   dynamic "service_connect_defaults" {
     for_each = length(var.cluster_service_connect_defaults) > 0 ? [var.cluster_service_connect_defaults] : []
 


### PR DESCRIPTION
When I tried to enable Fargate ephemeral storage encryption using the module, it wasn't supported. However, when I checked the Terraform documentation for the aws_ecs_cluster resource, I found that the managed_storage_configuration block is available there. This block, however, is missing in the module.