### PR TITLE
docs: Update for usage of the triggers variable with force_new_deployment

### DIFF
--- a/modules/service/README.md
+++ b/modules/service/README.md
@@ -318,7 +318,7 @@ module "ecs_service" {
 | <a name="input_tasks_iam_role_tags"></a> [tasks\_iam\_role\_tags](#input\_tasks\_iam\_role\_tags) | A map of additional tags to add to the IAM role created | `map(string)` | `{}` | no |
 | <a name="input_tasks_iam_role_use_name_prefix"></a> [tasks\_iam\_role\_use\_name\_prefix](#input\_tasks\_iam\_role\_use\_name\_prefix) | Determines whether the IAM role name (`tasks_iam_role_name`) is used as a prefix | `bool` | `true` | no |
 | <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Create, update, and delete timeout configurations for the service | `map(string)` | `{}` | no |
-| <a name="input_triggers"></a> [triggers](#input\_triggers) | Map of arbitrary keys and values that, when changed, will trigger an in-place update (redeployment). Useful with `timestamp()` | `any` | `{}` | no |
+| <a name="input_triggers"></a> [triggers](#input\_triggers) | Map of arbitrary keys and values that, when changed, will trigger an in-place update (redeployment). Useful with `plantimestamp()` | `any` | `{}` | no |
 | <a name="input_volume"></a> [volume](#input\_volume) | Configuration block for volumes that containers in your task may use | `any` | `{}` | no |
 | <a name="input_wait_for_steady_state"></a> [wait\_for\_steady\_state](#input\_wait\_for\_steady\_state) | If true, Terraform will wait for the service to reach a steady state before continuing. Default is `false` | `bool` | `null` | no |
 | <a name="input_wait_until_stable"></a> [wait\_until\_stable](#input\_wait\_until\_stable) | Whether terraform should wait until the task set has reached `STEADY_STATE` | `bool` | `null` | no |

--- a/modules/service/variables.tf
+++ b/modules/service/variables.tf
@@ -183,7 +183,7 @@ variable "timeouts" {
 }
 
 variable "triggers" {
-  description = "Map of arbitrary keys and values that, when changed, will trigger an in-place update (redeployment). Useful with `timestamp()`"
+  description = "Map of arbitrary keys and values that, when changed, will trigger an in-place update (redeployment). Useful with `plantimestamp()`"
   type        = any
   default     = {}
 }


### PR DESCRIPTION
## Description

The `triggers` varable is used to ensure `force_new_deployment=true` is respected by Terraform, for when you want to have an ECS Service that deploys tasks with image tags that don't change - e.g. if you use rolling image tags, perhaps managed outside of terraform entirely.

This `triggers` feature was originally implemented from [this issue](https://github.com/hashicorp/terraform-provider-aws/issues/13528) which provides an example like so:

```
resource "aws_ecs_service" "foo" {
  ...
  force_new_deployment = true

  triggers = {
    update = timestamp()  # force update in-place every apply
  }
}
```

But this won't work because `timestamp()` is evaluated at apply time, not plan - as explained [here](https://github.com/hashicorp/terraform/issues/22461#issuecomment-521771936). The solution is that the `plantimestamp()` function must be used instead.

The [main terraform-provider-aws docs](https://github.com/hashicorp/terraform-provider-aws/blob/main/website/docs/r/ecs_service.html.markdown#redeploy-service-on-every-apply) have already been updated it seems - but that's not a very visible doc, so I think it's important to have it updated here as well.

## Motivation and Context
This PR just updates the documentation here to make it consistent and fix the current example in the docs which won't work; so that if one visits the documentation page [here](https://registry.terraform.io/modules/terraform-aws-modules/ecs/aws/latest/submodules/service), it is no longer misleading.

## Breaking Changes
None - this is purely a small documentation update.
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
