### PR TITLE
feat: Add support for multiple services inside service_connect_configuration

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -119,6 +119,7 @@ module "ecs" {
               port     = local.container_port
               dns_name = local.container_name
             }
+
             timeout = {
               idle_timeout_seconds        = 20
               per_request_timeout_seconds = 30


### PR DESCRIPTION
## Description
Add support for multiple services inside service_connect_configuration

## Motivation and Context
According to [the Documentation of ECS](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-connect-concepts.html#service-connect-concepts-config), service_connect_configuration can configure multiple client-server services and [hashicorp/aws provider supports for deploying it (as far as I know) after the major version 5](https://registry.terraform.io/providers/hashicorp/aws/5.0.0/docs/resources/ecs_service#service_connect_configuration).

Closes https://github.com/terraform-aws-modules/terraform-aws-ecs/issues/289

Quote: https://registry.terraform.io/providers/hashicorp/aws/4.43.0/docs/resources/ecs_service#service_connect_configuration

However this module does not accept the list of Service Connect service objects and that is the issue this PR wants to fix.

## Breaking Changes
Backward compatible

## How Has This Been Tested?
Tested in a example and also in a private project (cannot share here)