### PR TITLE
fix: Pass missing `versionConsistency` argument, correct `conditions` to `condition`

### DIFF
--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -282,7 +282,7 @@ data "aws_iam_policy_document" "task_exec" {
       }
 
       dynamic "condition" {
-        for_each = statement.value.conditions != null ? statement.value.conditions : []
+        for_each = statement.value.condition != null ? statement.value.condition : []
 
         content {
           test     = condition.value.test

--- a/modules/container-definition/main.tf
+++ b/modules/container-definition/main.tf
@@ -55,10 +55,10 @@ locals {
     portMappings           = var.portMappings != null ? [for p in var.portMappings : { for k, v in p : k => v if v != null }] : null
     privileged             = local.is_not_windows ? var.privileged : null
     pseudoTerminal         = var.pseudoTerminal
-    restartPolicy          = { for k, v in var.restartPolicy : k => v if v != null }
     readonlyRootFilesystem = local.is_not_windows ? var.readonlyRootFilesystem : null
     repositoryCredentials  = var.repositoryCredentials
     resourceRequirements   = var.resourceRequirements
+    restartPolicy          = { for k, v in var.restartPolicy : k => v if v != null }
     secrets                = var.secrets
     startTimeout           = var.startTimeout
     stopTimeout            = var.stopTimeout

--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -657,7 +657,7 @@ data "aws_iam_policy_document" "service" {
       }
 
       dynamic "condition" {
-        for_each = statement.value.conditions != null ? statement.value.conditions : []
+        for_each = statement.value.condition != null ? statement.value.condition : []
 
         content {
           test     = condition.value.test
@@ -740,6 +740,7 @@ module "container_definition" {
   systemControls         = try(coalesce(each.value.systemControls, var.container_definition_defaults.systemControls), null)
   ulimits                = try(coalesce(each.value.ulimits, var.container_definition_defaults.ulimits), null)
   user                   = try(coalesce(each.value.user, var.container_definition_defaults.user), null)
+  versionConsistency     = try(coalesce(each.value.versionConsistency, var.container_definition_defaults.versionConsistency), null)
   volumesFrom            = try(coalesce(each.value.volumesFrom, var.container_definition_defaults.volumesFrom), null)
   workingDirectory       = try(coalesce(each.value.workingDirectory, var.container_definition_defaults.workingDirectory), null)
 
@@ -1023,7 +1024,7 @@ data "aws_iam_policy_document" "task_exec" {
       }
 
       dynamic "condition" {
-        for_each = statement.value.conditions != null ? statement.value.conditions : []
+        for_each = statement.value.condition != null ? statement.value.condition : []
 
         content {
           test     = condition.value.test


### PR DESCRIPTION
## Description
- Pass missing `versionConsistency` argument to `service` sub-module
- Correct IAM policy statement `conditions` to `condition`

## Motivation and Context
- Resolves #301
- Resolves #302

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
