### PR TITLE
docs: Update for cluster submodule example code which use renamed vars

### DIFF
--- a/modules/cluster/README.md
+++ b/modules/cluster/README.md
@@ -19,9 +19,9 @@ For more details see the [design doc](https://github.com/terraform-aws-modules/t
 module "ecs_cluster" {
   source = "terraform-aws-modules/ecs/aws//modules/cluster"
 
-  cluster_name = "ecs-fargate"
+  name = "ecs-fargate"
 
-  cluster_configuration = {
+  configuration = {
     execute_command_configuration = {
       logging = "OVERRIDE"
       log_configuration = {
@@ -53,9 +53,9 @@ module "ecs_cluster" {
 module "ecs_cluster" {
   source = "terraform-aws-modules/ecs/aws//modules/cluster"
 
-  cluster_name = "ecs-ec2"
+  name = "ecs-ec2"
 
-  cluster_configuration = {
+  configuration = {
     execute_command_configuration = {
       logging = "OVERRIDE"
       log_configuration = {


### PR DESCRIPTION
## Description

1.  Following cluster submodule's variables were renamed by this [commit](https://github.com/terraform-aws-modules/terraform-aws-ecs/blame/master/modules/cluster/variables.tf#L52)
```diff
- cluster_name
+ name
- cluster_configuration
+ configuration
```

2. But [cluster  module's example code](https://github.com/terraform-aws-modules/terraform-aws-ecs/blob/master/modules/cluster/README.md?plain=1#L22) on README is still using old name variables.

3. This PR update these example code

## Motivation and Context
just want to put correct example code for cluster submodule for the reader.

## Breaking Changes
No, this PR only include updates for readme

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
