### PR TITLE
fix: Add logs:CreateLogGroup action to task execution policy

### DIFF
--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -216,6 +216,7 @@ data "aws_iam_policy_document" "task_exec" {
     actions = [
       "logs:CreateLogStream",
       "logs:PutLogEvents",
+      "logs:CreateLogGroup",
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
## Description

I added the `logs:CreateLogGroup` action to the task execution policy statement.

## Motivation and Context

Creating a task through terraform works, but it doesn't start with the following error displayed in the UI:

```
ResourceInitializationError: failed to validate logger args: create stream has been retried 1 times: failed to create Cloudwatch log group: AccessDeniedException: User: arn:aws:sts::[redacted]:assumed-role/[redacted]-ecs-task-execution-role/[redacted] is not authorized to perform: logs:CreateLogGroup on resource: arn:aws:logs:eu-central-1:[redacted]:log-group:[redacted]:log-stream: because no identity-based policy allows the logs:CreateLogGroup action : exit status 1
```

## Breaking Changes

No, fixes the latest major version.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

I tested it with our own project, locally. I don't have an AWS account to deploy anything I want in.
