### PR TITLE
feat: Allow optional `initProcessEnabled` when `enable_execute_command` is `true`

### DIFF
--- a/modules/container-definition/main.tf
+++ b/modules/container-definition/main.tf
@@ -24,7 +24,7 @@ locals {
   )
 
   # tflint-ignore: terraform_naming_convention
-  linuxParameters = var.enable_execute_command ? merge(var.linuxParameters, { "initProcessEnabled" : true }) : var.linuxParameters
+  linuxParameters = var.enable_execute_command ? merge({ "initProcessEnabled" : true }, var.linuxParameters) : merge({ "initProcessEnabled" : false }, var.linuxParameters)
 
   definition = {
     command                = var.command


### PR DESCRIPTION
## Description

Reverts to previous logic here: https://github.com/terraform-aws-modules/terraform-aws-ecs/pull/136/files
This allows user to override optional `initProcessEnabled` as needed. 

## Motivation and Context
Closes: https://github.com/terraform-aws-modules/terraform-aws-ecs/issues/311

## Breaking Changes
No.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
