### PR TITLE
Use provided region in aws:SourceArn condition

### DIFF
--- a/modules/service/README.md
+++ b/modules/service/README.md
@@ -222,7 +222,6 @@ module "ecs_service" {
 | [aws_iam_policy_document.tasks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.tasks_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_subnet.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
 
 ## Inputs

--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -11,7 +11,6 @@ data "aws_caller_identity" "current" {
 locals {
   account_id = try(data.aws_caller_identity.current[0].account_id, "")
   partition  = try(data.aws_partition.current[0].partition, "")
-  region     = try(data.aws_region.current[0].region, "")
 }
 
 ################################################################################
@@ -1184,7 +1183,7 @@ data "aws_iam_policy_document" "tasks_assume" {
     condition {
       test     = "ArnLike"
       variable = "aws:SourceArn"
-      values   = ["arn:${local.partition}:ecs:${local.region}:${local.account_id}:*"]
+      values   = ["arn:${local.partition}:ecs:${var.region}:${local.account_id}:*"]
     }
 
     condition {

--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -1,6 +1,3 @@
-data "aws_region" "current" {
-  count = var.create ? 1 : 0
-}
 data "aws_partition" "current" {
   count = var.create ? 1 : 0
 }


### PR DESCRIPTION
## Description

Update the  `ECSTasksAssumeRole` policy to use the `region` variable in the assume role condition.

## Motivation and Context

Prior to this change the "current" region was used which would never match and prevent launching any tasks.

## Breaking Changes

None that I am aware of.

## How Has This Been Tested?

- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
