### PR TITLE
feat: Add role_arn to volume_configuration -> managed_ebs_volume

### DIFF
--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -617,7 +617,7 @@ resource "aws_ecs_service" "ignore_task_definition" {
           file_system_type = managed_ebs_volume.value.file_system_type
           iops             = managed_ebs_volume.value.iops
           kms_key_id       = managed_ebs_volume.value.kms_key_id
-          role_arn         = local.infrastructure_iam_role_arn
+          role_arn         = coalesce(managed_ebs_volume.value.role_arn, local.infrastructure_iam_role_arn)
           size_in_gb       = managed_ebs_volume.value.size_in_gb
           snapshot_id      = managed_ebs_volume.value.snapshot_id
 
@@ -1712,7 +1712,7 @@ resource "aws_vpc_security_group_egress_rule" "this" {
 ############################################################################################
 
 locals {
-  needs_infrastructure_iam_role  = var.volume_configuration != null || var.vpc_lattice_configurations != null
+  needs_infrastructure_iam_role  = (var.volume_configuration != null && (!contains(keys(var.volume_configuration.managed_ebs_volume), "role_arn") || var.volume_configuration.managed_ebs_volume.role_arn == null)) || var.vpc_lattice_configurations != null
   create_infrastructure_iam_role = var.create && var.create_infrastructure_iam_role && local.needs_infrastructure_iam_role
   infrastructure_iam_role_arn    = local.needs_infrastructure_iam_role ? try(aws_iam_role.infrastructure_iam_role[0].arn, var.infrastructure_iam_role_arn) : null
   infrastructure_iam_role_name   = coalesce(var.infrastructure_iam_role_name, var.name, "NotProvided")

--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -297,7 +297,7 @@ resource "aws_ecs_service" "this" {
           file_system_type = managed_ebs_volume.value.file_system_type
           iops             = managed_ebs_volume.value.iops
           kms_key_id       = managed_ebs_volume.value.kms_key_id
-          role_arn         = local.infrastructure_iam_role_arn
+          role_arn         = coalesce(managed_ebs_volume.value.role_arn, local.infrastructure_iam_role_arn)
           size_in_gb       = managed_ebs_volume.value.size_in_gb
           snapshot_id      = managed_ebs_volume.value.snapshot_id
 

--- a/modules/service/variables.tf
+++ b/modules/service/variables.tf
@@ -307,6 +307,7 @@ variable "volume_configuration" {
       file_system_type = optional(string)
       iops             = optional(number)
       kms_key_id       = optional(string)
+      role_arn         = optional(string)
       size_in_gb       = optional(number)
       snapshot_id      = optional(string)
       tag_specifications = optional(list(object({


### PR DESCRIPTION
## Description
Add `role_arn` as a variable to `container-definition` -> `volume_configuration` -> `managed_ebs_volume`.

## Motivation and Context
This will allow a custom role to be attached to the volume.

## Breaking Changes
No.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request