### PR TITLE
fix: Correct loop extraction logic for `tls.issuer_cert_authority`

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -144,6 +144,14 @@ module "ecs" {
 
             port_name      = local.container_name
             discovery_name = local.container_name
+            # Example TLS configuration
+            # tls = {
+            #   issuer_cert_authority = {
+            #     aws_pca_authority_arn = aws_acmpca_certificate_authority.this.arn
+            #   }
+            #   role_arn = module.tls_role.iam_role_arn
+            #   kms_key = module.tls_role.kms_key_arn
+            # }
           }
         ]
       }

--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -250,9 +250,14 @@ resource "aws_ecs_service" "this" {
             for_each = service.value.tls != null ? [service.value.tls] : []
 
             content {
-              issuer_cert_authority {
-                aws_pca_authority_arn = issuer_cert_authority.value.aws_pca_authority_arn
+              dynamic "issuer_cert_authority" {
+                for_each = [tls.value.issuer_cert_authority]
+
+                content {
+                  aws_pca_authority_arn = issuer_cert_authority.value.aws_pca_authority_arn
+                }
               }
+
               kms_key  = tls.value.kms_key
               role_arn = tls.value.role_arn
             }

--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -250,14 +250,9 @@ resource "aws_ecs_service" "this" {
             for_each = service.value.tls != null ? [service.value.tls] : []
 
             content {
-              dynamic "issuer_cert_authority" {
-                for_each = tls.value.issuer_cert_authority
-
-                content {
-                  aws_pca_authority_arn = issuer_cert_authority.value.aws_pca_authority_arn
-                }
+              issuer_cert_authority {
+                aws_pca_authority_arn = issuer_cert_authority.value.aws_pca_authority_arn
               }
-
               kms_key  = tls.value.kms_key
               role_arn = tls.value.role_arn
             }


### PR DESCRIPTION
## Description
This removes an unnecessary for_each and dynamic setting for `issuer_cert_authority` which is a required setting when using tls.

## Motivation and Context
This fixes a bug:

```
Error: Unsupported attribute
on .terraform/modules/web_ecs_service/modules/service/main.tf line 257, in resource "aws_ecs_service" "this":
                  aws_pca_authority_arn = issuer_cert_authority.value.aws_pca_authority_arn
issuer_cert_authority.value is "arn:aws:acm-pca:us-east-2:SNIP:certificate-authority/SNIP"
Can't access attributes on a primitive-typed value (string).
```

## Breaking Changes
No breaking changes.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
