### PR TITLE
docs: Correct example usage of `service_connect_configuration.service` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,10 @@ module "ecs" {
           client_alias = {
             port     = 80
             dns_name = "ecs-sample"
-            }
-            port_name      = "ecs-sample"
-            discovery_name = "ecs-sample"
-          }]
+          }
+          port_name      = "ecs-sample"
+          discovery_name = "ecs-sample"
+        }]
       }
 
       load_balancer = {

--- a/README.md
+++ b/README.md
@@ -100,14 +100,14 @@ module "ecs" {
 
       service_connect_configuration = {
         namespace = "example"
-        service = {
+        service = [{
           client_alias = {
             port     = 80
             dns_name = "ecs-sample"
-          }
-          port_name      = "ecs-sample"
-          discovery_name = "ecs-sample"
-        }
+            }
+            port_name      = "ecs-sample"
+            discovery_name = "ecs-sample"
+          }]
       }
 
       load_balancer = {


### PR DESCRIPTION
When running as the example in README I got 
```
 attribute "service_connect_configuration": attribute "service": list of object required.
 ```
 Fixing that