### PR TITLE
fix: `tls.issuer_cert_authority` dynamic block

### DIFF
--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -571,7 +571,7 @@ resource "aws_ecs_service" "ignore_task_definition" {
 
             content {
               dynamic "issuer_cert_authority" {
-                for_each = tls.value.issuer_cert_authority
+                for_each = [tls.value.issuer_cert_authority]
 
                 content {
                   aws_pca_authority_arn = issuer_cert_authority.value.aws_pca_authority_arn


### PR DESCRIPTION
## Description
Fixes dynamic block for_each setting for the `aws_ecs_service.ignore_task_definition` resource same as the [fix done here](https://github.com/terraform-aws-modules/terraform-aws-ecs/pull/337). 

## Motivation and Context
Closes: https://github.com/terraform-aws-modules/terraform-aws-ecs/issues/340
Related: https://github.com/terraform-aws-modules/terraform-aws-ecs/pull/337

## Breaking Changes
No.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
