### PR TITLE
fix: Ignore changes in container_definitions

### DIFF
--- a/modules/service/README.md
+++ b/modules/service/README.md
@@ -193,6 +193,7 @@ module "ecs_service" {
 | [aws_appautoscaling_target.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_target) | resource |
 | [aws_ecs_service.ignore_task_definition](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
 | [aws_ecs_service.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
+| [aws_ecs_task_definition.ignore_task_definition_changes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
 | [aws_ecs_task_definition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
 | [aws_ecs_task_set.ignore_task_definition](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_set) | resource |
 | [aws_ecs_task_set.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_set) | resource |

--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -869,11 +869,11 @@ module "container_definition" {
 
 locals {
   create_task_definition = var.create && var.create_task_definition
-  task_definition        = local.create_task_definition ? aws_ecs_task_definition.this[0].arn : var.task_definition_arn
+  task_definition        = local.create_task_definition ? try(aws_ecs_task_definition.this[0].arn, aws_ecs_task_definition.ignore_task_definition_changes[0].arn) : var.task_definition_arn
 }
 
 resource "aws_ecs_task_definition" "this" {
-  count = local.create_task_definition ? 1 : 0
+  count = local.create_task_definition && !var.ignore_task_definition_changes ? 1 : 0
 
   region = var.region
 
@@ -1003,6 +1003,141 @@ resource "aws_ecs_task_definition" "this" {
 
   lifecycle {
     create_before_destroy = true
+  }
+}
+
+resource "aws_ecs_task_definition" "ignore_task_definition_changes" {
+  count = local.create_task_definition && var.ignore_task_definition_changes ? 1 : 0
+
+  region = var.region
+
+  # Convert map of maps to array of maps before JSON encoding
+  container_definitions  = jsonencode([for k, v in module.container_definition : v.container_definition])
+  cpu                    = var.cpu
+  enable_fault_injection = var.enable_fault_injection
+
+  dynamic "ephemeral_storage" {
+    for_each = var.ephemeral_storage != null ? [var.ephemeral_storage] : []
+
+    content {
+      size_in_gib = ephemeral_storage.value.size_in_gib
+    }
+  }
+
+  execution_role_arn = try(aws_iam_role.task_exec[0].arn, var.task_exec_iam_role_arn)
+  family             = coalesce(var.family, var.name)
+
+  ipc_mode     = var.ipc_mode
+  memory       = var.memory
+  network_mode = var.network_mode
+  pid_mode     = var.pid_mode
+
+  dynamic "placement_constraints" {
+    for_each = var.task_definition_placement_constraints != null ? var.task_definition_placement_constraints : {}
+
+    content {
+      expression = placement_constraints.value.expression
+      type       = placement_constraints.value.type
+    }
+  }
+
+  dynamic "proxy_configuration" {
+    for_each = var.proxy_configuration != null ? [var.proxy_configuration] : []
+
+    content {
+      container_name = proxy_configuration.value.container_name
+      properties     = proxy_configuration.value.properties
+      type           = proxy_configuration.value.type
+    }
+  }
+
+  requires_compatibilities = var.requires_compatibilities
+
+  dynamic "runtime_platform" {
+    for_each = var.runtime_platform != null ? [var.runtime_platform] : []
+
+    content {
+      cpu_architecture        = runtime_platform.value.cpu_architecture
+      operating_system_family = runtime_platform.value.operating_system_family
+    }
+  }
+
+  skip_destroy  = var.skip_destroy
+  task_role_arn = try(aws_iam_role.tasks[0].arn, var.tasks_iam_role_arn)
+  track_latest  = var.track_latest
+
+  dynamic "volume" {
+    for_each = var.volume != null ? var.volume : {}
+
+    content {
+      configure_at_launch = volume.value.configure_at_launch
+
+      dynamic "docker_volume_configuration" {
+        for_each = volume.value.docker_volume_configuration != null ? [volume.value.docker_volume_configuration] : []
+
+        content {
+          autoprovision = docker_volume_configuration.value.autoprovision
+          driver        = docker_volume_configuration.value.driver
+          driver_opts   = docker_volume_configuration.value.driver_opts
+          labels        = docker_volume_configuration.value.labels
+          scope         = docker_volume_configuration.value.scope
+        }
+      }
+
+      dynamic "efs_volume_configuration" {
+        for_each = volume.value.efs_volume_configuration != null ? [volume.value.efs_volume_configuration] : []
+
+        content {
+          dynamic "authorization_config" {
+            for_each = efs_volume_configuration.value.authorization_config != null ? [efs_volume_configuration.value.authorization_config] : []
+
+            content {
+              access_point_id = authorization_config.value.access_point_id
+              iam             = authorization_config.value.iam
+            }
+          }
+
+          file_system_id          = efs_volume_configuration.value.file_system_id
+          root_directory          = efs_volume_configuration.value.root_directory
+          transit_encryption      = efs_volume_configuration.value.transit_encryption
+          transit_encryption_port = efs_volume_configuration.value.transit_encryption_port
+        }
+      }
+
+      dynamic "fsx_windows_file_server_volume_configuration" {
+        for_each = volume.value.fsx_windows_file_server_volume_configuration != null ? [volume.value.fsx_windows_file_server_volume_configuration] : []
+
+        content {
+          dynamic "authorization_config" {
+            for_each = fsx_windows_file_server_volume_configuration.value.authorization_config != null ? [fsx_windows_file_server_volume_configuration.value.authorization_config] : []
+
+            content {
+              credentials_parameter = authorization_config.value.credentials_parameter
+              domain                = authorization_config.value.domain
+            }
+          }
+
+          file_system_id = fsx_windows_file_server_volume_configuration.value.file_system_id
+          root_directory = fsx_windows_file_server_volume_configuration.value.root_directory
+        }
+      }
+
+      host_path = volume.value.host_path
+      name      = coalesce(volume.value.name, volume.key)
+    }
+  }
+
+  tags = merge(var.tags, var.task_tags)
+
+  depends_on = [
+    aws_iam_role_policy_attachment.tasks,
+    aws_iam_role_policy_attachment.task_exec,
+    aws_iam_role_policy_attachment.task_exec_additional,
+  ]
+
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes        = [container_definitions]
   }
 }
 

--- a/modules/service/outputs.tf
+++ b/modules/service/outputs.tf
@@ -56,7 +56,7 @@ output "task_definition_revision" {
 
 output "task_definition_family" {
   description = "The unique name of the task definition"
-  value       = try(aws_ecs_task_definition.this[0].family, null)
+  value       = try(aws_ecs_task_definition.ignore_task_definition_changes[0].family, aws_ecs_task_definition.this[0].family, null)
 }
 
 ################################################################################


### PR DESCRIPTION
## Description
Add `aws_ecs_task_definition` which ignore changes in `container_definitions`.

## Motivation and Context
I created a service and initial task definition via terraform, and update `task_definition` via [GitHub Action](https://github.com/aws-actions/amazon-ecs-render-task-definition). It updates `container_definitions`, which leads to situation, where terraform is trying to recreate a task definition back.
This PR applies the same logic as having `ignore_cnages` aws_ecs_service.

## Breaking Changes
N/A

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I deployed version 6.2.2, and then I deployed modified version and tested task definition update with GitHub Actions 
- [x] I have executed `pre-commit run -a` on my pull request