### PR TITLE
feat: Allow Toggling `initProcessEnabled` independent of `enable_execute_command`

### DIFF
--- a/modules/container-definition/main.tf
+++ b/modules/container-definition/main.tf
@@ -28,8 +28,8 @@ locals {
   # 2. We then merge in the `initProcessEnabled` attribute based on whether `enable_execute_command` is true or false
   # This also means we will always have something in `linuxParameters` (it will never be `null` or `{}`)
   # Terraform doesn't allow us to set `initProcessEnabled` to `true` on one side only of the conditional, so we have to merge it in on both sides
-  # However, in the `true` case, we set it last to ensure `initProcessEnabled` is always `true` when `enable_execute_command` is true
-  # and the "psuedo-default" is `false` when `enable_execute_command` is false (but can still be overridden by the user)
+  # The default is `true` when `enable_execute_command` is true but can be overridden by the user
+  # and the "pseudo-default" is `false` when `enable_execute_command` is false (but can still be overridden by the user)
   # tflint-ignore: terraform_naming_convention
   linuxParameters = var.enable_execute_command ? merge({ "initProcessEnabled" : true }, local.trimedLinuxParameters) : merge({ "initProcessEnabled" : false }, local.trimedLinuxParameters)
 


### PR DESCRIPTION
## Description
Since `initProcessEnabled` is an optional parameter, allowing this to be overridden even when `enable_execute_command` is set to `true`. It is recommended to be set to `true` by AWS but is optional. 

## Motivation and Context
Relates to: 
- https://github.com/terraform-aws-modules/terraform-aws-ecs/issues/311
- https://github.com/terraform-aws-modules/terraform-aws-ecs/pull/319
- https://github.com/terraform-aws-modules/terraform-aws-ecs/pull/136

## Breaking Changes
No.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
