### PR TITLE
docs: Correct Fargate examples listener rules

### DIFF
--- a/examples/fargate/main.tf
+++ b/examples/fargate/main.tf
@@ -325,17 +325,18 @@ module "alb" {
           priority = 1
           actions = [
             {
-              type = "weighted-forward"
-              target_groups = [
-                {
-                  target_group_key = "ex_ecs"
-                  weight           = 100
-                },
-                {
-                  target_group_key = "ex_ecs_alternate"
-                  weight           = 0
-                }
-              ]
+              weighted_forward = {
+                target_groups = [
+                  {
+                    target_group_key = "ex_ecs"
+                    weight           = 100
+                  },
+                  {
+                    target_group_key = "ex_ecs_alternate"
+                    weight           = 0
+                  }
+                ]
+              }
             }
           ]
           conditions = [
@@ -350,13 +351,14 @@ module "alb" {
           priority = 2
           actions = [
             {
-              type = "weighted-forward"
-              target_groups = [
-                {
-                  target_group_key = "ex_ecs_alternate"
-                  weight           = 100
-                }
-              ]
+              weighted_forward = {
+                target_groups = [
+                  {
+                    target_group_key = "ex_ecs_alternate"
+                    weight           = 100
+                  }
+                ]
+              }
             }
           ]
           conditions = [


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

The ALB module expects actions to be structured with the action type as a nested object (like `weighted_forward`, `forward`, `redirect`, etc.) rather than using a separate `type` field. The module code checks for these nested objects to determine which action configuration to apply.

When the code had `type = "weighted-forward"`, the module couldn't find any of the expected action objects (`authenticate_cognito`, `authenticate_oidc`, `fixed_response`, `forward`, `weighted_forward`, or `redirect`), which caused the "Insufficient action blocks" error.

Terraform configuration should now apply successfully without the action block error.



### before:

```
actions = [
  {
    type = "weighted-forward"
    target_groups = [...]
  }
]

```
### after:

```
actions = [
  {
    weighted_forward = {
      target_groups = [...]
    }
  }
]
```
----


## Motivation and Context
- Resolves #365 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No breaking changes, this is a fix to the current build error.

## How Has This Been Tested?

I updated code and I did a terraform init and apply on AWS and manually verified the results.
code auto installed module dependency alb v10.2 https://github.com/terraform-aws-modules/terraform-aws-alb/releases/tag/v10.2.0
There are other issues unrelated to this PR and bug like: 

- HTTPS not loading  on ALB dns url [example:https://ex-fargate-12345.eu-west-1.elb.amazonaws.com/]
- HTTP repeatedly reloading  on ALB dns url [example:http://ex-fargate-12345.eu-west-1.elb.amazonaws.com/]
- fluentbit logging reporting a permission error in cloudwatch

`ime="2025-11-06T20:23:46Z" level=error msg="[firehose 0] AccessDeniedException: User: arn:aws:sts::12345:assumed-role/ex-fargate-12345/abcd is not authorized to perform: firehose:PutRecordBatch on resource: arn:aws:firehose:eu-west-1:12345:deliverystream/my-stream because no identity-based policy allows the firehose:PutRecordBatch action\n\tstatus code: 400, request id: abc123\n"`

`[2025/11/06 20:23:46] [ warn] [engine] chunk '1-12345.flb' cannot be retried: task_id=2, input=forward.1 > output=firehose.1
`

You can now deploy and pull up the site instead of just getting a terraform error.  I will report the other issues separately.

```
Providers required by configuration:
.
├── provider[registry.terraform.io/hashicorp/aws] >= 6.14.0
├── module.ecs_service
│   ├── provider[registry.terraform.io/hashicorp/aws] >= 6.14.0
│   └── module.container_definition
│       └── provider[registry.terraform.io/hashicorp/aws] >= 6.14.0
├── module.ecs_task_definition
│   ├── provider[registry.terraform.io/hashicorp/aws] >= 6.14.0
│   └── module.container_definition
│       └── provider[registry.terraform.io/hashicorp/aws] >= 6.14.0
├── module.vpc
│   └── provider[registry.terraform.io/hashicorp/aws] >= 6.0.0
├── module.alb
│   └── provider[registry.terraform.io/hashicorp/aws] >= 6.19.0
└── module.ecs_cluster
    └── provider[registry.terraform.io/hashicorp/aws] >= 6.14.0 
```

- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
