### PR TITLE
fix: Improve security group creation logic

### DIFF
--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -1876,8 +1876,7 @@ data "aws_subnet" "this" {
 }
 
 resource "aws_security_group" "this" {
-  count = local.create_security_group && (var.vpc_id != null ||
-  length(var.subnet_ids) > 0) ? 1 : 0
+  count = local.create_security_group && length(var.subnet_ids) > 0 ? 1 : 0
 
   region = var.region
 


### PR DESCRIPTION
## Description

- This resolves issue #374 where `subnet_ids` was declared as optional but caused an error when not provided. The problem occurred when `create_security_group` was enabled (the default) with `network_mode = "awsvpc"` but `subnet_ids` was empty. The data source attempted to query `element(var.subnet_ids, 0)` on an empty list, causing a runtime error. The fix adds conditional logic to only create the subnet data source when `subnet_ids` is non-empty, and only creates the security group when subnet information is available to derive or use the VPC ID. The VPC ID reference now uses the `one()` function to safely handle the optional data source, preferring an explicit `vpc_id` when provided. The count expressions avoid null checks to prevent Terraform planning errors when `vpc_id` is a computed value from another resource. Users can now omit `subnet_ids` when they don't need the module to create a security group, or provide only `subnet_ids` to have the VPC ID automatically derived, making the module's behavior consistent with the variable's optional declaration.

## Motivation and Context

- Closes #374 
- @bryantbiggs if you have a chance to review this logic update, that would be awesome! I know the team is probably out in Vegas this way though, so no worries

## How Has This Been Tested?
- [X] Existing examples validate this functionality
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [X] I have executed `pre-commit run -a` on my pull request

