### PR TITLE
docs: Switch fluentbit output from firehose to stdout in examples

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -169,9 +169,7 @@ module "ecs" {
           logConfiguration = {
             logDriver = "awsfirelens"
             options = {
-              Name                    = "firehose"
-              region                  = local.region
-              delivery_stream         = "my-stream"
+              Name                    = "stdout"
               log-driver-buffer-limit = "2097152"
             }
           }

--- a/examples/fargate/main.tf
+++ b/examples/fargate/main.tf
@@ -128,9 +128,7 @@ module "ecs_service" {
       logConfiguration = {
         logDriver = "awsfirelens"
         options = {
-          Name                    = "firehose"
-          region                  = local.region
-          delivery_stream         = "my-stream"
+          Name                    = "stdout"
           log-driver-buffer-limit = "2097152"
         }
       }


### PR DESCRIPTION
## Description
I have updated the Fluent Bit sidecar configuration in `examples/fargate` and `examples/complete` to switch the log output from `firehose` to `stdout`.

**Specific changes:**
* Changed `Name` from `firehose` to `stdout` in FireLens options.
* Removed `region` and `delivery_stream` parameters (as they are not needed for stdout).
* Preserved `log-driver-buffer-limit`.

## Motivation and Context
The previous configuration attempted to ship logs to AWS Firehose. This caused the example workloads to crash or fail to start if the specific Firehose delivery streams or region parameters were missing or invalid. Switching to `stdout` allows the examples to run successfully out-of-the-box without external dependencies.

- Resolves #381

## Breaking Changes
- [ ] Yes
- [x] No

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request

**Verification steps taken:**
* Ran `terraform validate` on both directories (passed successfully).
* Verified via `git diff` that only the log configuration blocks were modified (Minimal Diff Strategy).