### PR TITLE
fix: Support for service nullable cpu and memory

### DIFF
--- a/modules/service/variables.tf
+++ b/modules/service/variables.tf
@@ -631,6 +631,7 @@ variable "cpu" {
   description = "Number of cpu units used by the task. If the `requires_compatibilities` is `FARGATE` this field is required"
   type        = number
   default     = 1024
+  nullable    = true
 }
 
 variable "enable_fault_injection" {
@@ -663,6 +664,7 @@ variable "memory" {
   description = "Amount (in MiB) of memory used by the task. If the `requires_compatibilities` is `FARGATE` this field is required"
   type        = number
   default     = 2048
+  nullable    = true
 }
 
 variable "network_mode" {


### PR DESCRIPTION
## Description

The Container Definitions allow to global cpu/memory be not defined as long as each container provides at least the values for memory, however, when created from the service, it is currently imposible to set service cpu/memory to null as variables have a default value and are not nullable.

See issue #90

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
