### PR TITLE
fix: Allow custom deployment percentages for DAEMON strategy

### DIFF
--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -121,8 +121,8 @@ resource "aws_ecs_service" "this" {
     }
   }
 
-  deployment_maximum_percent         = local.is_daemon || local.is_external_deployment ? null : var.deployment_maximum_percent
-  deployment_minimum_healthy_percent = local.is_daemon || local.is_external_deployment ? null : var.deployment_minimum_healthy_percent
+  deployment_maximum_percent         = local.is_external_deployment ? null : var.deployment_maximum_percent
+  deployment_minimum_healthy_percent = local.is_external_deployment ? null : var.deployment_minimum_healthy_percent
   desired_count                      = local.is_daemon || local.is_external_deployment ? null : var.desired_count
   enable_ecs_managed_tags            = var.enable_ecs_managed_tags
   enable_execute_command             = var.enable_execute_command


### PR DESCRIPTION
Fixes #390 

## Motivation
Currently, when `scheduling_strategy` is set to `DAEMON`, the module forces `deployment_minimum_healthy_percent` and `deployment_maximum_percent` to `null`.
This triggers AWS defaults (100%/200%), which causes **deployment deadlocks** during rolling updates because ECS cannot stop the running task on a single node to make room for the new one.

## Solution
This PR removes the `local.is_daemon` check from `modules/service/main.tf`.
This allows users to explicitly set `deployment_minimum_healthy_percent = 0`, enabling ECS to kill the old task before starting the new one during a DAEMON service update.