### PR TITLE
feat: Update infrastructure IAM policy permissions with latest AWS `AmazonECSInfrastructureRolePolicyForManagedInstances` managed policy

### DIFF
--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -595,10 +595,7 @@ data "aws_iam_policy_document" "infrastructure" {
       "arn:${local.partition}:ec2:${local.region}:*:instance/*",
       "arn:${local.partition}:ec2:${local.region}:*:network-interface/*",
       "arn:${local.partition}:ec2:${local.region}:*:launch-template/*",
-      "arn:${local.partition}:ec2:${local.region}:*:security-group/*",
-      "arn:${local.partition}:ec2:${local.region}:*:subnet/*",
       "arn:${local.partition}:ec2:${local.region}:*:volume/*",
-      "arn:${local.partition}:ec2:${local.region}:*:image/*",
     ]
 
     condition {
@@ -606,6 +603,16 @@ data "aws_iam_policy_document" "infrastructure" {
       variable = "aws:RequestTag/AmazonECSManaged"
       values   = [true]
     }
+  }
+
+  statement {
+    sid     = "CreateFleetForSupportingResources"
+    actions = ["ec2:CreateFleet"]
+    resources = [
+      "arn:${local.partition}:ec2:${local.region}:*:subnet/*",
+      "arn:${local.partition}:ec2:${local.region}:*:security-group/*",
+      "arn:${local.partition}:ec2:${local.region}:*:image/*",
+    ]
   }
 
   statement {


### PR DESCRIPTION
## Description

- Align infrastructure IAM policy with the updated [AmazonECSInfrastructureRolePolicyForManagedInstances](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonECSInfrastructureRolePolicyForManagedInstances.html) AWS managed policy
- Split `CreateFleet` resources into two statements, moving subnet, security-group, and image to a separate statement without tag conditions

## Motivation and Context

- Resolves #392

## Breaking Changes

No

## How Has This Been Tested?

- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request

```bash
$ tofu apply -auto-approve
...
module.ecs_cluster.aws_ecs_capacity_provider.this["mi-example"]: Creation complete after 1s
module.ecs_cluster.aws_ecs_cluster_capacity_providers.this[0]: Creation complete after 10s
...
Apply complete! Resources: 56 added, 0 changed, 0 destroyed.
```