### PR TITLE
fix(service): Avoid requiring subnet_ids when vpc_id is provided

### DIFF
--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -1896,7 +1896,7 @@ locals {
 }
 
 data "aws_subnet" "this" {
-  count = local.create_security_group ? 1 : 0
+  count = local.create_security_group && var.vpc_id == null && length(var.subnet_ids) > 0 ? 1 : 0
 
   region = var.region
 
@@ -1911,7 +1911,7 @@ resource "aws_security_group" "this" {
   name        = var.security_group_use_name_prefix ? null : local.security_group_name
   name_prefix = var.security_group_use_name_prefix ? "${local.security_group_name}-" : null
   description = try(coalesce(var.security_group_description, (var.disable_v7_default_name_description ? null : "Security group for ECS Service ${var.name}")), null)
-  vpc_id      = var.vpc_id != null ? var.vpc_id : data.aws_subnet.this[0].vpc_id
+  vpc_id      = var.vpc_id != null ? var.vpc_id : try(data.aws_subnet.this[0].vpc_id, null)
 
   tags = merge(
     var.tags,
@@ -1921,6 +1921,11 @@ resource "aws_security_group" "this" {
 
   lifecycle {
     create_before_destroy = true
+
+    precondition {
+      condition = var.vpc_id != null || length(var.subnet_ids) > 0
+      error_message = "Either var.vpc_id or var.subnet_ids must be provided to determine the VPC"
+    }
   }
 }
 

--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -1923,7 +1923,7 @@ resource "aws_security_group" "this" {
     create_before_destroy = true
 
     precondition {
-      condition = var.vpc_id != null || length(var.subnet_ids) > 0
+      condition     = var.vpc_id != null || length(var.subnet_ids) > 0
       error_message = "Either var.vpc_id or var.subnet_ids must be provided to determine the VPC"
     }
   }


### PR DESCRIPTION
Fixes #405

## Summary
Fixes a regression where `subnet_ids` were required even when `vpc_id` was provided, causing errors when `subnet_ids` was empty.

## Problem
The module attempted to resolve subnet information using:
`element(var.subnet_ids, 0)` even when `vpc_id` was already provided.

This resulted in errors such as:
"cannot use element function with an empty list"

Additionally, when both `vpc_id` and `subnet_ids` were not provided, the module failed later with unclear errors.

## Changes
- Updated subnet data source condition to only run when:
  - `vpc_id` is null, and
  - `subnet_ids` is non-empty
- Replaced direct access to `data.aws_subnet.this[0]` with `try(...)` to safely handle cases where the data source is not created
- Added a lifecycle `precondition` to enforce that either `vpc_id` or `subnet_ids` must be provided

## Result
- Prevents crashes when `subnet_ids` is empty
- Ensures `vpc_id` takes precedence when provided
- Improves error handling with a clear validation message
- Handles edge cases safely and predictably

## Additional Notes
This change maintains backward compatibility while improving robustness and input validation.