### PR TITLE
TLCE-6845 remove deprecated attribute

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -1,0 +1,17 @@
+name: PR Checks
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  deploy:
+    name: PR Jira validation check
+    runs-on: [ubuntu-latest]
+    steps:
+       - name: PR Jira validation check
+         uses: triplelift-internal/actions/pr-check@v1.0
+         with:
+          github_token: '${{ secrets.GH_ORG_TOKEN }}'
+          jira_user: '${{ secrets.JIRA_USER }}'
+          jira_token: '${{ secrets.JIRA_TOKEN }}'

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # CODEOWNERS
 * @triplelift-internal/team-cloud-engineering
-.github/* @triplelift-internal/team-cloud-engineering-deployers
+.github/** @triplelift-internal/team-cloud-engineering-deployers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# CODEOWNERS
+* @triplelift-internal/team-cloud-engineering
+.github/* @triplelift-internal/team-cloud-engineering-deployers

--- a/main.tf
+++ b/main.tf
@@ -106,7 +106,7 @@ module "service" {
   cpu                           = try(each.value.cpu, 1024)
   ephemeral_storage             = try(each.value.ephemeral_storage, {})
   family                        = try(each.value.family, null)
-  inference_accelerator         = try(each.value.inference_accelerator, {})
+  #inference_accelerator         = try(each.value.inference_accelerator, {})
   ipc_mode                      = try(each.value.ipc_mode, null)
   memory                        = try(each.value.memory, 2048)
   network_mode                  = try(each.value.network_mode, "awsvpc")

--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -632,14 +632,6 @@ resource "aws_ecs_task_definition" "this" {
   execution_role_arn = try(aws_iam_role.task_exec[0].arn, var.task_exec_iam_role_arn)
   family             = coalesce(var.family, var.name)
 
-  dynamic "inference_accelerator" {
-    for_each = var.inference_accelerator
-
-    content {
-      device_name = inference_accelerator.value.device_name
-      device_type = inference_accelerator.value.device_type
-    }
-  }
 
   ipc_mode     = var.ipc_mode
   memory       = var.memory

--- a/modules/service/variables.tf
+++ b/modules/service/variables.tf
@@ -304,12 +304,6 @@ variable "family" {
   default     = null
 }
 
-variable "inference_accelerator" {
-  description = "Configuration block(s) with Inference Accelerators settings"
-  type        = any
-  default     = {}
-}
-
 variable "ipc_mode" {
   description = "IPC resource namespace to be used for the containers in the task The valid values are `host`, `task`, and `none`"
   type        = string

--- a/wrappers/service/main.tf
+++ b/wrappers/service/main.tf
@@ -64,7 +64,7 @@ module "wrapper" {
   iam_role_tags                      = try(each.value.iam_role_tags, var.defaults.iam_role_tags, {})
   iam_role_use_name_prefix           = try(each.value.iam_role_use_name_prefix, var.defaults.iam_role_use_name_prefix, true)
   ignore_task_definition_changes     = try(each.value.ignore_task_definition_changes, var.defaults.ignore_task_definition_changes, false)
-  inference_accelerator              = try(each.value.inference_accelerator, var.defaults.inference_accelerator, {})
+  #inference_accelerator              = try(each.value.inference_accelerator, var.defaults.inference_accelerator, {})
   ipc_mode                           = try(each.value.ipc_mode, var.defaults.ipc_mode, null)
   launch_type                        = try(each.value.launch_type, var.defaults.launch_type, "FARGATE")
   load_balancer                      = try(each.value.load_balancer, var.defaults.load_balancer, {})


### PR DESCRIPTION
This pull request primarily removes support for ECS Inference Accelerators from the Terraform modules and configuration, and introduces workflow and ownership improvements. The most important changes are grouped below.

### ECS Inference Accelerator Removal

* Removed the `inference_accelerator` variable from `modules/service/variables.tf`, and all related configuration and usage in `modules/service/main.tf`, `main.tf`, and `wrappers/service/main.tf`. This means the module no longer supports configuring inference accelerators for ECS tasks. [[1]](diffhunk://#diff-b18e50c335b12c99c73f93b73035361c6ebcb1480ec00bbc01f7274d9724daf1L307-L312) [[2]](diffhunk://#diff-28bc80a19e12810ad239a26d08f533cc89218888b325a01eaf473610578e0bcdL635-L642) [[3]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL109-R109) [[4]](diffhunk://#diff-fb396bee485e0d09e5a212d2034e21857cc9ace8afe2009aa1f12c53405d3c37L67-R67)

### CI/CD and Ownership Improvements

* Added a new GitHub Actions workflow `.github/workflows/pr-check.yaml` to validate PRs against Jira requirements, improving PR process automation.
* Added a `CODEOWNERS` file to assign ownership of all files to the `team-cloud-engineering` group and `.github` files to `team-cloud-engineering-deployers`, clarifying code responsibility.